### PR TITLE
Ignore 'AlreadyExists" API error when creating IPAM IP

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.22-bullseye AS builder
+FROM golang:1.22-bullseye AS builder
 
 ARG GOARCH=''
 

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ run: all
 
 .PHONY: docker-build
 docker-build: ## Build docker image with the manager.
-	docker build -t ${IMG} $(GITHUB_PAT_MOUNT) .
+	DOCKER_BUILDKIT=1 docker build -t ${IMG} $(GITHUB_PAT_MOUNT) .
 
 .PHONY: docker-push
 docker-push: ## Push docker image with the manager.

--- a/main.go
+++ b/main.go
@@ -27,6 +27,7 @@ import (
 	pl_router "github.com/coredhcp/coredhcp/plugins/router"
 	pl_searchdomains "github.com/coredhcp/coredhcp/plugins/searchdomains"
 	pl_serverid "github.com/coredhcp/coredhcp/plugins/serverid"
+	pl_sleep "github.com/coredhcp/coredhcp/plugins/sleep"
 	pl_staticroute "github.com/coredhcp/coredhcp/plugins/staticroute"
 	pl_bluefield "github.com/ironcore-dev/fedhcp/plugins/bluefield"
 	pl_ipam "github.com/ironcore-dev/fedhcp/plugins/ipam"
@@ -76,6 +77,7 @@ var desiredPlugins = []*plugins.Plugin{
 	&pl_router.Plugin,
 	&pl_searchdomains.Plugin,
 	&pl_serverid.Plugin,
+	&pl_sleep.Plugin,
 	&pl_staticroute.Plugin,
 	&pl_bluefield.Plugin,
 	&pl_ipam.Plugin,

--- a/plugins/ipam/k8s.go
+++ b/plugins/ipam/k8s.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"reflect"
 	"strings"
+	"time"
 
 	ipamv1alpha1 "github.com/ironcore-dev/ipam/api/ipam/v1alpha1"
 	"github.com/pkg/errors"
@@ -152,7 +153,8 @@ func (k K8sClient) createIpamIP(ipaddr net.IP, mac net.HardwareAddr) error {
 				}
 
 				k.EventRecorder.Eventf(existingIpamIP, corev1.EventTypeNormal, "Deleted", "Deleted old IPAM IP")
-				log.Infof("Old IP deleted from subnet %s/%s", subnet.Namespace, subnet.Name)
+				log.Infof("Old IP deleted from subnet %s/%s, sleeping for 5 seconds, so the finalizer can run", subnet.Namespace, subnet.Name)
+				time.Sleep(5 * time.Second)
 				createIpamIP = true
 			}
 		}

--- a/plugins/ipam/k8s.go
+++ b/plugins/ipam/k8s.go
@@ -165,17 +165,16 @@ func (k K8sClient) createIpamIP(ipaddr net.IP, mac net.HardwareAddr) error {
 				err = errors.Wrapf(err, "Failed to create IP %s/%s", ipamIP.Namespace, ipamIP.Name)
 				return err
 			}
-
 			if apierrors.IsAlreadyExists(err) {
 				// do not create IP, because the deletion is not yet ready
-				break
+				noop()
 			} else {
 				log.Infof("New IP created in subnet %s/%s", subnet.Namespace, subnet.Name)
 				k.EventRecorder.Eventf(ipamIP, corev1.EventTypeNormal, "Created", "Created IPAM IP")
-				break
 			}
+		} else {
+			log.Infof("IP already exists in subnet %s/%s, nothing to do", subnet.Namespace, subnet.Name)
 		}
-		log.Infof("IP already exists in subnet %s/%s, nothing to do", subnet.Namespace, subnet.Name)
 		break
 	}
 
@@ -224,3 +223,5 @@ func checkIPv6InCIDR(ip net.IP, cidrStr string) bool {
 	// Check if the CIDR contains the IP
 	return cidrNet.Contains(ip)
 }
+
+func noop() {}


### PR DESCRIPTION
It was most probably to deferred deletion, the IP creation was queued and will succeed after the existing IP is deleted
