### PR TITLE
Enable CGO at build time

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ ARG TARGETARCH
 
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg \
-    CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH GO111MODULE=on go build -ldflags="-s -w" -a -o fedhcp main.go
+    CGO_ENABLED=1 GOOS=$TARGETOS GOARCH=$TARGETARCH GO111MODULE=on go build -ldflags="-s -w" -a -o fedhcp main.go
 
 FROM gcr.io/distroless/static-debian11
 WORKDIR /

--- a/Makefile
+++ b/Makefile
@@ -1,20 +1,13 @@
 # Image URL to use all building/pushing image targets
 IMG ?= controller:latest
 
-GITHUB_PAT_PATH ?=
-ifeq (,$(GITHUB_PAT_PATH))
-GITHUB_PAT_MOUNT ?=
-else
-GITHUB_PAT_MOUNT ?= --secret id=github_pat,src=$(GITHUB_PAT_PATH)
-endif
-
 .PHONY: target/fedhcp
 
 all: target/fedhcp
 
 target/fedhcp:
 	mkdir -p target
-	CGO_ENABLED=0 go build -o target/fedhcp .
+	CGO_ENABLED=1 go build -o target/fedhcp .
 
 clean:
 	rm -rf target


### PR DESCRIPTION
It's needed for the sqlite functionality of the `range` IPv4 plugin

