### PR TITLE
Make PXE plugin not brake the plugin chain

### DIFF
--- a/plugins/pxeboot/plugin.go
+++ b/plugins/pxeboot/plugin.go
@@ -94,7 +94,7 @@ func pxeBootHandler4(req, resp *dhcpv4.DHCPv4) (*dhcpv4.DHCPv4, bool) {
 
 	if tftpBootFileOption == nil || tftpServerNameOption == nil || ipxeBootFileOption == nil {
 		// nothing to do
-		return resp, true
+		return resp, false
 	}
 
 	if req.IsOptionRequested(dhcpv4.OptionBootfileName) {
@@ -129,7 +129,7 @@ func pxeBootHandler4(req, resp *dhcpv4.DHCPv4) (*dhcpv4.DHCPv4, bool) {
 	}
 
 	log.Debugf("Sent DHCPv4 response: %s", resp.Summary())
-	return resp, true
+	return resp, false
 }
 
 func setup6(args ...string) (handler.Handler6, error) {
@@ -150,13 +150,13 @@ func pxeBootHandler6(req, resp dhcpv6.DHCPv6) (dhcpv6.DHCPv6, bool) {
 
 	if tftpOption == nil || ipxeOption == nil {
 		// nothing to do
-		return resp, true
+		return resp, false
 	}
 	decap, err := req.GetInnerMessage()
 	if err != nil {
 		log.Errorf("Could not decapsulate request: %v", err)
 		// drop the request, this is probably a critical error in the packet.
-		return nil, true
+		return nil, false
 	}
 
 	if decap.IsOptionRequested(dhcpv6.OptionBootfileURL) {
@@ -187,5 +187,5 @@ func pxeBootHandler6(req, resp dhcpv6.DHCPv6) (dhcpv6.DHCPv6, bool) {
 	}
 
 	log.Debugf("Sent DHCPv6 response: %s", resp.Summary())
-	return resp, true
+	return resp, false
 }

--- a/plugins/pxeboot/plugin_test.go
+++ b/plugins/pxeboot/plugin_test.go
@@ -142,8 +142,8 @@ func TestPXERequested6(t *testing.T) {
 		t.Fatal("plugin did not return a message")
 	}
 
-	if !stop {
-		t.Error("plugin does not interrupt processing, but it should have")
+	if stop {
+		t.Error("plugin interrupted processing, but it shouldn't have")
 	}
 	opts := resp.GetOption(dhcpv6.OptionBootfileURL)
 	if len(opts) != numberOptsBootFileURL {
@@ -179,8 +179,8 @@ func TestTFTPRequested6(t *testing.T) {
 		t.Fatal("plugin did not return a message")
 	}
 
-	if !stop {
-		t.Error("plugin does not interrupt processing, but it should have")
+	if stop {
+		t.Error("plugin interrupted processing, but it shouldn't have")
 	}
 	opts := resp.GetOption(dhcpv6.OptionBootfileURL)
 	if len(opts) != numberOptsBootFileURL {
@@ -221,8 +221,8 @@ func TestWrongPXERequested6(t *testing.T) {
 		t.Fatal("plugin did not return a message")
 	}
 
-	if !stop {
-		t.Error("plugin does not interrupt processing, but it should have")
+	if stop {
+		t.Error("plugin interrupted processing, but it shouldn't have")
 	}
 	opts := resp.GetOption(dhcpv6.OptionBootfileURL)
 	if len(opts) != numberOptsBootFileURL {
@@ -253,8 +253,8 @@ func TestWrongTFTPRequested6(t *testing.T) {
 		t.Fatal("plugin did not return a message")
 	}
 
-	if !stop {
-		t.Error("plugin does not interrupt processing, but it should have")
+	if stop {
+		t.Error("plugin interrupted processing, but it shouldn't have")
 	}
 	opts := resp.GetOption(dhcpv6.OptionBootfileURL)
 	if len(opts) != numberOptsBootFileURL {
@@ -283,8 +283,8 @@ func TestPXENotRequested6(t *testing.T) {
 		t.Fatal("plugin did not return a message")
 	}
 
-	if !stop {
-		t.Error("plugin does not interrupt processing, but it should have")
+	if stop {
+		t.Error("plugin interrupted processing, but it shouldn't have")
 	}
 	opts := resp.GetOption(dhcpv6.OptionBootfileURL)
 	if len(opts) != numberOptsBootFileURL {
@@ -313,8 +313,8 @@ func TestTFTPNotRequested6(t *testing.T) {
 		t.Fatal("plugin did not return a message")
 	}
 
-	if !stop {
-		t.Error("plugin does not interrupt processing, but it should have")
+	if stop {
+		t.Error("plugin interrupted processing, but it shouldn't have")
 	}
 	opts := resp.GetOption(dhcpv6.OptionBootfileURL)
 	if len(opts) != numberOptsBootFileURL {
@@ -345,8 +345,8 @@ func TestPXERequested4(t *testing.T) {
 		t.Fatal("plugin did not return a message")
 	}
 
-	if !stop {
-		t.Error("plugin does not interrupt processing, but it should have")
+	if stop {
+		t.Error("plugin interrupted processing, but it shouldn't have")
 	}
 
 	bootFileURL := dhcpv4.GetString(dhcpv4.OptionBootfileName, resp.Options)
@@ -376,8 +376,8 @@ func TestTFTPRequested4(t *testing.T) {
 		t.Fatal("plugin did not return a message")
 	}
 
-	if !stop {
-		t.Error("plugin does not interrupt processing, but it should have")
+	if stop {
+		t.Error("plugin interrupted processing, but it shouldn't have")
 	}
 
 	const protocol = "tftp"
@@ -411,8 +411,8 @@ func TestPXENotRequested4(t *testing.T) {
 		t.Fatal("plugin did not return a message")
 	}
 
-	if !stop {
-		t.Error("plugin does not interrupt processing, but it should have")
+	if stop {
+		t.Error("plugin interrupted processing, but it shouldn't have")
 	}
 
 	bootFileURL := dhcpv4.GetString(dhcpv4.OptionBootfileName, resp.Options)
@@ -439,8 +439,8 @@ func TestTFTPNotRequested4(t *testing.T) {
 		t.Fatal("plugin did not return a message")
 	}
 
-	if !stop {
-		t.Error("plugin does not interrupt processing, but it should have")
+	if stop {
+		t.Error("plugin interrupted processing, but it shouldn't have")
 	}
 
 	tftpServerName := dhcpv4.GetString(dhcpv4.OptionTFTPServerName, resp.Options)
@@ -474,8 +474,8 @@ func TestWrongPXERequested4(t *testing.T) {
 		t.Fatal("plugin did not return a message")
 	}
 
-	if !stop {
-		t.Error("plugin does not interrupt processing, but it should have")
+	if stop {
+		t.Error("plugin interrupted processing, but it shouldn't have")
 	}
 
 	bootFileURL := dhcpv4.GetString(dhcpv4.OptionBootfileName, resp.Options)
@@ -505,8 +505,8 @@ func TestWrongTFTPRequested4(t *testing.T) {
 		t.Fatal("plugin did not return a message")
 	}
 
-	if !stop {
-		t.Error("plugin does not interrupt processing, but it should have")
+	if stop {
+		t.Error("plugin interrupted processing, but it shouldn't have")
 	}
 
 	tftpServerName := dhcpv4.GetString(dhcpv4.OptionTFTPServerName, resp.Options)


### PR DESCRIPTION
Otherwise `PXE` and `file` plugins are not useable together in IPv4, because both brake the plugin chain, though, both plugins are needed for the bootstrap pipeline

S. https://github.com/coredhcp/coredhcp/blob/master/plugins/file/plugin.go#L199

