### PR TITLE
Add prefix delegation handling for `onmetal` plugin

### DIFF
--- a/plugins/httpboot/plugin_test.go
+++ b/plugins/httpboot/plugin_test.go
@@ -51,6 +51,7 @@ func Init6(bootURL string) {
 }
 
 /* parametrization */
+
 func TestWrongNumberArgs(t *testing.T) {
 	_, _, err := parseArgs("foo", "bar")
 	if err == nil {

--- a/plugins/onmetal/plugin_test.go
+++ b/plugins/onmetal/plugin_test.go
@@ -18,6 +18,7 @@ const (
 var (
 	expectedIPAddress6 = net.IP{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2}
 	expectedIAID       = [4]byte{1, 2, 3, 4}
+	expectedPrefix     = "2001:db8:1111:2222:3333::/80"
 )
 
 func Init6() {
@@ -28,7 +29,6 @@ func Init6() {
 }
 
 /* parametrization */
-
 func TestWrongNumberArgs(t *testing.T) {
 	_, err := setup6("not-needed-arg")
 	if err == nil {
@@ -155,4 +155,103 @@ func TestNoRelayIPAddressRequested6(t *testing.T) {
 		t.Error("plugin did not interrupt processing, but it should have")
 	}
 
+}
+func TestPrefixDelegationRequested6(t *testing.T) {
+	Init6()
+
+	req, err := dhcpv6.NewMessage()
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.MessageType = dhcpv6.MessageTypeRequest
+	req.AddOption(&dhcpv6.OptIANA{
+		IaId: expectedIAID,
+	})
+	req.AddOption(&dhcpv6.OptIAPD{
+		IaId:    expectedIAID,
+		T1:      preferredLifeTime,
+		T2:      validLifeTime,
+		Options: dhcpv6.PDOptions{},
+	})
+
+	relayedRequest, err := dhcpv6.EncapsulateRelay(req, dhcpv6.MessageTypeRelayForward, net.ParseIP("2001:db8:1111:2222:3333:4444:5555:6666"), net.IPv6loopback)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	stub, err := dhcpv6.NewMessage()
+	if err != nil {
+		t.Fatal(err)
+	}
+	stub.MessageType = dhcpv6.MessageTypeReply
+
+	resp, stop := handler6(relayedRequest, stub)
+	if resp == nil {
+		t.Fatal("plugin did not return a message")
+	}
+	if stop {
+		t.Error("plugin interrupted processing, but it shouldn't have")
+	}
+
+	opts := resp.GetOption(dhcpv6.OptionIAPD)
+	if len(opts) != optionEnabled {
+		t.Fatalf("Expected %d IAPD option, got %d: %v", optionEnabled, len(opts), opts)
+	}
+
+	iapd := resp.(*dhcpv6.Message).Options.OneIAPD()
+	t1 := iapd.T1
+	t2 := iapd.T2
+	pref := iapd.Options.Options[0].(*dhcpv6.OptIAPrefix).Prefix
+
+	if t1 != preferredLifeTime {
+		t.Errorf("Expected T1 %d, got %d", preferredLifeTime, t1)
+	}
+
+	if t2 != validLifeTime {
+		t.Errorf("Expected T2 %d, got %d", validLifeTime, t2)
+	}
+
+	if iapd.IaId != expectedIAID {
+		t.Errorf("expected IAID %d, got %d", expectedIAID, iapd.IaId)
+	}
+
+	if pref.String() != expectedPrefix {
+		t.Errorf("expected prefix %v, got %v", expectedPrefix, pref)
+	}
+}
+func TestPrefixDelegationNotRequested6(t *testing.T) {
+	Init6()
+
+	req, err := dhcpv6.NewMessage()
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.MessageType = dhcpv6.MessageTypeRequest
+	req.AddOption(&dhcpv6.OptIANA{
+		IaId: expectedIAID,
+	})
+
+	relayedRequest, err := dhcpv6.EncapsulateRelay(req, dhcpv6.MessageTypeRelayForward, net.IPv6loopback, net.IPv6loopback)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	stub, err := dhcpv6.NewMessage()
+	if err != nil {
+		t.Fatal(err)
+	}
+	stub.MessageType = dhcpv6.MessageTypeReply
+
+	resp, stop := handler6(relayedRequest, stub)
+	if resp == nil {
+		t.Fatal("plugin did not return a message")
+	}
+	if stop {
+		t.Error("plugin interrupted processing, but it shouldn't have")
+	}
+
+	opts := resp.GetOption(dhcpv6.OptionIAPD)
+	if len(opts) != optionDisabled {
+		t.Fatalf("Expected %d IAPD option, got %d: %v", optionDisabled, len(opts), opts)
+	}
 }


### PR DESCRIPTION
Deliver prefix delegation (`/80`) if the client asked for `IA_PD`

Implements https://github.com/ironcore-dev/FeDHCP/issues/179