### PR TITLE
Refactor flag parsing and logging

### DIFF
--- a/internal/kubernetes/client.go
+++ b/internal/kubernetes/client.go
@@ -6,26 +6,26 @@ package kubernetes
 import (
 	"fmt"
 
+	ipamv1alpha1 "github.com/ironcore-dev/ipam/api/ipam/v1alpha1"
 	metalv1alpha1 "github.com/ironcore-dev/metal-operator/api/v1alpha1"
 	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 )
 
-var kubeClient client.Client
+var (
+	scheme     = runtime.NewScheme()
+	kubeClient client.Client
+)
+
+func init() {
+	utilruntime.Must(ipamv1alpha1.AddToScheme(scheme))
+	utilruntime.Must(metalv1alpha1.AddToScheme(scheme))
+}
 
 func InitClient() error {
-	if kubeClient != nil {
-		return nil
-	}
-
 	cfg := config.GetConfigOrDie()
-
-	scheme := runtime.NewScheme()
-	if err := metalv1alpha1.AddToScheme(scheme); err != nil {
-		return fmt.Errorf("unable to add metalv1alpha1 to scheme: %w", err)
-	}
-
 	var err error
 	kubeClient, err = client.New(cfg, client.Options{Scheme: scheme})
 	if err != nil {
@@ -39,6 +39,4 @@ func SetClient(client *client.Client) {
 	kubeClient = *client
 }
 
-func GetClient() client.Client {
-	return kubeClient
-}
+func GetClient() client.Client { return kubeClient }

--- a/plugins/metal/plugin.go
+++ b/plugins/metal/plugin.go
@@ -11,8 +11,6 @@ import (
 	"os"
 	"strings"
 
-	"gopkg.in/yaml.v2"
-
 	"github.com/coredhcp/coredhcp/handler"
 	"github.com/coredhcp/coredhcp/logger"
 	"github.com/coredhcp/coredhcp/plugins"
@@ -23,6 +21,7 @@ import (
 	ipamv1alpha1 "github.com/ironcore-dev/ipam/api/ipam/v1alpha1"
 	metalv1alpha1 "github.com/ironcore-dev/metal-operator/api/v1alpha1"
 	"github.com/mdlayher/netx/eui64"
+	"gopkg.in/yaml.v3"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	controllerruntime "sigs.k8s.io/controller-runtime"
 )


### PR DESCRIPTION
# Proposed Changes

Use idiomatic golang flag parsing. Use propper logging setup instead of custom logger with custom flags.

```
Usage of ./bin/fedhcp:
  -config string
        config file
  -kubeconfig string
        Paths to a kubeconfig. Only required if out-of-cluster.
  -list-plugins
        list plugins
```

This is a breaking change as the flag names have changed.