### PR TITLE
Add `breaking` labeling to release drafter configuration

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,6 +1,9 @@
 name-template: 'v$RESOLVED_VERSION'
 tag-template: 'v$RESOLVED_VERSION'
 categories:
+  - title: '⚠️ Breaking'
+    labels:
+      - 'breaking'
   - title: '🚀 Features'
     labels:
       - 'feature'
@@ -51,6 +54,9 @@ autolabeler:
   - label: 'enhancement'
     branch:
       - '/enh\/.+/'
+  - label: 'chore'
+    branch:
+      - '/chore\/.+/'
 template: |
   ## Changes
   $CHANGES

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,4 @@
-name: Lint Golang Codebase
+name: Lint
 
 on:
   pull_request:
@@ -14,6 +14,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'
-      - uses: golangci/golangci-lint-action@v6
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v6
         with:
           version: v1.61

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,8 +9,9 @@ issues:
   # restore some of the defaults
   # (fill in the rest as needed)
   exclude-rules:
-    - path: "api/*"
+    - path: "plugins/*"
       linters:
+        - dupl
         - lll
     - path: "internal/*"
       linters:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,41 @@
+run:
+  timeout: 10m
+  allow-parallel-runners: true
+
+issues:
+  # don't skip warning about doc comments
+  # don't exclude the default set of lint
+  exclude-use-default: false
+  # restore some of the defaults
+  # (fill in the rest as needed)
+  exclude-rules:
+    - path: "api/*"
+      linters:
+        - lll
+    - path: "internal/*"
+      linters:
+        - dupl
+        - lll
+linters:
+  disable-all: true
+  enable:
+    - copyloopvar
+    - dupl
+    - errcheck
+    - goconst
+    - gocyclo
+    - gofmt
+    - goimports
+    - gosimple
+    - govet
+    - ineffassign
+    - ginkgolinter
+    - lll
+    - misspell
+    - nakedret
+    - prealloc
+    - staticcheck
+    - typecheck
+    - unconvert
+    - unparam
+    - unused

--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -9,7 +9,7 @@ Source: https://github.com/ironcore-dev/FeDHCP
 Files:
   .github/*
   .gitignore
-  .golangci.yaml
+  .golangci.yml
   Dockerfile
   Makefile
   config/*

--- a/internal/kubernetes/client.go
+++ b/internal/kubernetes/client.go
@@ -5,12 +5,12 @@ package kubernetes
 
 import (
 	"fmt"
-	"k8s.io/client-go/rest"
 
 	ipamv1alpha1 "github.com/ironcore-dev/ipam/api/ipam/v1alpha1"
 	metalv1alpha1 "github.com/ironcore-dev/metal-operator/api/v1alpha1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 )

--- a/main.go
+++ b/main.go
@@ -6,7 +6,6 @@ package main
 import (
 	"flag"
 	"fmt"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"os"
 
 	"github.com/coredhcp/coredhcp/config"
@@ -35,6 +34,7 @@ import (
 	"github.com/ironcore-dev/fedhcp/plugins/onmetal"
 	"github.com/ironcore-dev/fedhcp/plugins/oob"
 	"github.com/ironcore-dev/fedhcp/plugins/pxeboot"
+	"k8s.io/apimachinery/pkg/util/sets"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )

--- a/plugins/httpboot/plugin.go
+++ b/plugins/httpboot/plugin.go
@@ -206,7 +206,9 @@ func fetchUKIURL(url string, clientIPs []string) (string, error) {
 		log.Errorf("HTTP request failed: %v", err)
 		return "", err
 	}
-	defer resp.Body.Close()
+	defer func() {
+		_ = resp.Body.Close()
+	}()
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {

--- a/plugins/httpboot/plugin_test.go
+++ b/plugins/httpboot/plugin_test.go
@@ -13,11 +13,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/insomniacslk/dhcp/iana"
-
 	"github.com/insomniacslk/dhcp/dhcpv4"
-
 	"github.com/insomniacslk/dhcp/dhcpv6"
+	"github.com/insomniacslk/dhcp/iana"
 )
 
 const (
@@ -285,7 +283,10 @@ func TestHTTPBootNotRelayedMsg6(t *testing.T) {
 func TestGenericHTTPBootRequested4(t *testing.T) {
 	Init4(expectedGenericBootURL)
 
-	req, err := dhcpv4.NewDiscovery(net.HardwareAddr{0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff}, dhcpv4.WithRequestedOptions(dhcpv4.OptionClassIdentifier))
+	req, err := dhcpv4.NewDiscovery(net.HardwareAddr{
+		0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff},
+		dhcpv4.WithRequestedOptions(dhcpv4.OptionClassIdentifier),
+	)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -320,7 +321,10 @@ func TestGenericHTTPBootRequested4(t *testing.T) {
 func TestMalformedHTTPBootRequested4(t *testing.T) {
 	Init4(expectedGenericBootURL)
 
-	req, err := dhcpv4.NewDiscovery(net.HardwareAddr{0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff}, dhcpv4.WithRequestedOptions(dhcpv4.OptionClassIdentifier))
+	req, err := dhcpv4.NewDiscovery(net.HardwareAddr{
+		0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff},
+		dhcpv4.WithRequestedOptions(dhcpv4.OptionClassIdentifier),
+	)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -385,7 +389,10 @@ func TestMalformedHTTPBootRequested4(t *testing.T) {
 func TestHTTPBootNotRequested4(t *testing.T) {
 	Init4(expectedGenericBootURL)
 
-	req, err := dhcpv4.NewDiscovery(net.HardwareAddr{0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff}, dhcpv4.WithRequestedOptions(dhcpv4.OptionClassIdentifier))
+	req, err := dhcpv4.NewDiscovery(net.HardwareAddr{
+		0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff},
+		dhcpv4.WithRequestedOptions(dhcpv4.OptionClassIdentifier),
+	)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -506,7 +513,8 @@ func TestCustomHTTPBootRequestedKnownMAC(t *testing.T) {
 	req.UpdateOption(&optVendorClass)
 
 	// not known LinkAddr
-	relayedRequest, err := dhcpv6.EncapsulateRelay(req, dhcpv6.MessageTypeRelayForward, net.IP{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2}, net.IPv6loopback)
+	relayedRequest, err := dhcpv6.EncapsulateRelay(req, dhcpv6.MessageTypeRelayForward,
+		net.IP{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2}, net.IPv6loopback)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -574,7 +582,8 @@ func TestCustomHTTPBootRequestedUnknownClient(t *testing.T) {
 	req.UpdateOption(&optVendorClass)
 
 	// not known LinkAddr
-	relayedRequest, err := dhcpv6.EncapsulateRelay(req, dhcpv6.MessageTypeRelayForward, net.IP{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2}, net.IPv6loopback)
+	relayedRequest, err := dhcpv6.EncapsulateRelay(req, dhcpv6.MessageTypeRelayForward,
+		net.IP{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2}, net.IPv6loopback)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/plugins/ipam/k8s.go
+++ b/plugins/ipam/k8s.go
@@ -8,12 +8,12 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"github.com/ironcore-dev/fedhcp/internal/kubernetes"
 	"net"
 	"os"
 	"reflect"
 	"strings"
 
+	"github.com/ironcore-dev/fedhcp/internal/kubernetes"
 	ipamv1alpha1 "github.com/ironcore-dev/ipam/api/ipam/v1alpha1"
 	ipam "github.com/ironcore-dev/ipam/clientgo/ipam"
 	"github.com/pkg/errors"
@@ -135,7 +135,10 @@ func (k K8sClient) getMatchingSubnet(subnetName string, ipaddr net.IP) (*ipamv1a
 	return subnet, nil
 }
 
-func (k K8sClient) prepareCreateIpamIP(subnetName string, ipaddr net.IP, mac net.HardwareAddr) (*ipamv1alpha1.IP, error) {
+func (k K8sClient) prepareCreateIpamIP(
+	subnetName string,
+	ipaddr net.IP,
+	mac net.HardwareAddr) (*ipamv1alpha1.IP, error) {
 	ip, err := ipamv1alpha1.IPAddrFromString(ipaddr.String())
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse IP %s: %w", ipaddr, err)
@@ -176,23 +179,28 @@ func (k K8sClient) prepareCreateIpamIP(subnetName string, ipaddr net.IP, mac net
 		noop()
 	} else {
 		if !reflect.DeepEqual(ipamIP.Spec, existingIpamIP.Spec) {
-			log.Debugf("IP mismatch:\nold IP: %v,\nnew IP: %v", prettyFormat(existingIpamIP.Spec), prettyFormat(ipamIP.Spec))
+			log.Debugf("IP mismatch:\nold IP: %v,\nnew IP: %v", prettyFormat(existingIpamIP.Spec),
+				prettyFormat(ipamIP.Spec))
 			log.Infof("Deleting old IP %s/%s", existingIpamIP.Namespace, existingIpamIP.Name)
 			// delete old IP object
 			err = k.Client.Delete(k.Ctx, existingIpamIP)
 			if err != nil {
-				return nil, fmt.Errorf("failed to delete IP %s/%s: %w", existingIpamIP.Namespace, existingIpamIP.Name, err)
+				return nil, fmt.Errorf("failed to delete IP %s/%s: %w", existingIpamIP.Namespace,
+					existingIpamIP.Name, err)
 			}
 
 			err = k.waitForDeletion(existingIpamIP)
 			if err != nil {
-				return nil, fmt.Errorf("failed to delete IP %s/%s: %w", existingIpamIP.Namespace, existingIpamIP.Name, err)
+				return nil, fmt.Errorf("failed to delete IP %s/%s: %w", existingIpamIP.Namespace,
+					existingIpamIP.Name, err)
 			}
 
 			k.EventRecorder.Eventf(existingIpamIP, corev1.EventTypeNormal, "Deleted", "Deleted old IPAM IP")
-			log.Infof("Old IP %s/%s deleted from subnet %s", existingIpamIP.Namespace, existingIpamIP.Name, existingIpamIP.Spec.Subnet.Name)
+			log.Infof("Old IP %s/%s deleted from subnet %s", existingIpamIP.Namespace, existingIpamIP.Name,
+				existingIpamIP.Spec.Subnet.Name)
 		} else {
-			log.Infof("IP %s/%s already exists in subnet %s, nothing to do", existingIpamIP.Namespace, existingIpamIP.Name, existingIpamIP.Spec.Subnet.Name)
+			log.Infof("IP %s/%s already exists in subnet %s, nothing to do", existingIpamIP.Namespace,
+				existingIpamIP.Name, existingIpamIP.Spec.Subnet.Name)
 			return nil, nil
 		}
 	}

--- a/plugins/ipam/plugin.go
+++ b/plugins/ipam/plugin.go
@@ -29,7 +29,8 @@ var (
 
 func parseArgs(args ...string) (string, []string, error) {
 	if len(args) < 2 {
-		return "", []string{""}, fmt.Errorf("at least two arguments must be passed to ipam plugin, a namespace and a comma-separated subnet names list, got %d", len(args))
+		return "", []string{""}, fmt.Errorf("at least two arguments must be passed to ipam plugin, a namespace "+
+			"and a comma-separated subnet names list, got %d", len(args))
 	}
 
 	namespace := args[0]

--- a/plugins/metal/plugin_test.go
+++ b/plugins/metal/plugin_test.go
@@ -89,32 +89,32 @@ var _ = Describe("Endpoint", func() {
 
 	It("Setup6 should return error if less arguments are provided", func() {
 		_, err := setup6()
-		Expect(err).NotTo(BeNil())
+		Expect(err).To(HaveOccurred())
 	})
 
 	It("Setup6 should return error if more arguments are provided", func() {
 		_, err := setup6("foo", "bar")
-		Expect(err).NotTo(BeNil())
+		Expect(err).To(HaveOccurred())
 	})
 
 	It("Setup6 should return error if config file does not exist", func() {
 		_, err := setup6("does-not-exist.yaml")
-		Expect(err).NotTo(BeNil())
+		Expect(err).To(HaveOccurred())
 	})
 
 	It("Setup4 should return error if less arguments are provided", func() {
 		_, err := setup4()
-		Expect(err).NotTo(BeNil())
+		Expect(err).To(HaveOccurred())
 	})
 
 	It("Setup4 should return error if more arguments are provided", func() {
 		_, err := setup4("foo", "bar")
-		Expect(err).NotTo(BeNil())
+		Expect(err).To(HaveOccurred())
 	})
 
 	It("Setup4 should return error if config file does not exist", func() {
 		_, err := setup4("does-not-exist.yaml")
-		Expect(err).NotTo(BeNil())
+		Expect(err).To(HaveOccurred())
 	})
 
 	It("Should return empty inventory list if the config file is malformed", func() {
@@ -196,26 +196,28 @@ var _ = Describe("Endpoint", func() {
 		Eventually(ip).Should(BeNil())
 	})
 
-	It("Should not create an endpoint for IPv6 DHCP request from a known machine without IP address", func(ctx SpecContext) {
-		mac, _ := net.ParseMAC(machineWithoutIPAddressMACAddress)
-		ip := net.ParseIP(linkLocalIPV6Prefix)
-		linkLocalIPV6Addr, _ := eui64.ParseMAC(ip, mac)
+	It("Should not create an endpoint for IPv6 DHCP request from a known machine without IP address",
+		func(ctx SpecContext) {
+			mac, _ := net.ParseMAC(machineWithoutIPAddressMACAddress)
+			ip := net.ParseIP(linkLocalIPV6Prefix)
+			linkLocalIPV6Addr, _ := eui64.ParseMAC(ip, mac)
 
-		req, _ := dhcpv6.NewMessage()
-		req.MessageType = dhcpv6.MessageTypeRequest
-		relayedRequest, _ := dhcpv6.EncapsulateRelay(req, dhcpv6.MessageTypeRelayForward, net.IPv6loopback, linkLocalIPV6Addr)
+			req, _ := dhcpv6.NewMessage()
+			req.MessageType = dhcpv6.MessageTypeRequest
+			relayedRequest, _ := dhcpv6.EncapsulateRelay(req, dhcpv6.MessageTypeRelayForward,
+				net.IPv6loopback, linkLocalIPV6Addr)
 
-		stub, _ := dhcpv6.NewMessage()
-		stub.MessageType = dhcpv6.MessageTypeReply
-		_, _ = handler6(relayedRequest, stub)
+			stub, _ := dhcpv6.NewMessage()
+			stub.MessageType = dhcpv6.MessageTypeReply
+			_, _ = handler6(relayedRequest, stub)
 
-		endpoint := &metalv1alpha1.Endpoint{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: machineWithoutIPAddressName,
-			},
-		}
-		Eventually(Get(endpoint)).Should(Satisfy(apierrors.IsNotFound))
-	})
+			endpoint := &metalv1alpha1.Endpoint{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: machineWithoutIPAddressName,
+				},
+			}
+			Eventually(Get(endpoint)).Should(Satisfy(apierrors.IsNotFound))
+		})
 
 	It("Should not create an endpoint for IPv6 DHCP request from a unknown machine", func(ctx SpecContext) {
 		mac, _ := net.ParseMAC(unknownMachineMACAddress)
@@ -271,21 +273,22 @@ var _ = Describe("Endpoint", func() {
 		DeferCleanup(k8sClient.Delete, endpoint)
 	})
 
-	It("Should not create an endpoint for IPv4 DHCP request from a known machine without IP address", func(ctx SpecContext) {
-		mac, _ := net.ParseMAC(machineWithoutIPAddressMACAddress)
+	It("Should not create an endpoint for IPv4 DHCP request from a known machine without IP address",
+		func(ctx SpecContext) {
+			mac, _ := net.ParseMAC(machineWithoutIPAddressMACAddress)
 
-		req, _ := dhcpv4.NewDiscovery(mac)
-		stub, _ := dhcpv4.NewReplyFromRequest(req)
+			req, _ := dhcpv4.NewDiscovery(mac)
+			stub, _ := dhcpv4.NewReplyFromRequest(req)
 
-		_, _ = handler4(req, stub)
+			_, _ = handler4(req, stub)
 
-		endpoint := &metalv1alpha1.Endpoint{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: machineWithoutIPAddressName,
-			},
-		}
-		Eventually(Get(endpoint)).Should(Satisfy(apierrors.IsNotFound))
-	})
+			endpoint := &metalv1alpha1.Endpoint{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: machineWithoutIPAddressName,
+				},
+			}
+			Eventually(Get(endpoint)).Should(Satisfy(apierrors.IsNotFound))
+		})
 
 	It("Should not create an endpoint for IPv6 DHCP request from a unknown machine", func(ctx SpecContext) {
 		mac, _ := net.ParseMAC(unknownMachineMACAddress)

--- a/plugins/onmetal/plugin_test.go
+++ b/plugins/onmetal/plugin_test.go
@@ -175,7 +175,8 @@ func TestPrefixDelegationRequested6(t *testing.T) {
 		Options: dhcpv6.PDOptions{},
 	})
 
-	relayedRequest, err := dhcpv6.EncapsulateRelay(req, dhcpv6.MessageTypeRelayForward, net.ParseIP("2001:db8:1111:2222:3333:4444:5555:6666"), net.IPv6loopback)
+	relayedRequest, err := dhcpv6.EncapsulateRelay(req, dhcpv6.MessageTypeRelayForward,
+		net.ParseIP("2001:db8:1111:2222:3333:4444:5555:6666"), net.IPv6loopback)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/plugins/oob/k8s.go
+++ b/plugins/oob/k8s.go
@@ -84,7 +84,11 @@ func NewK8sClient(namespace string, oobLabel string) (*K8sClient, error) {
 	return &k8sClient, nil
 }
 
-func (k K8sClient) getIp(ipaddr net.IP, mac net.HardwareAddr, exactIP bool, subnetType ipamv1alpha1.SubnetAddressType) (net.IP, error) {
+func (k K8sClient) getIp(
+	ipaddr net.IP,
+	mac net.HardwareAddr,
+	exactIP bool,
+	subnetType ipamv1alpha1.SubnetAddressType) (net.IP, error) {
 	var ipamIP *ipamv1alpha1.IP
 	macKey := strings.ReplaceAll(mac.String(), ":", "")
 
@@ -115,7 +119,8 @@ func (k K8sClient) getIp(ipaddr net.IP, mac net.HardwareAddr, exactIP bool, subn
 					return nil, err
 				}
 			} else {
-				log.Infof("Reserved IP %s (%s/%s) already exists in subnet %s", ipamIP.Status.Reserved.String(), ipamIP.Namespace, ipamIP.Name, ipamIP.Spec.Subnet.Name)
+				log.Infof("Reserved IP %s (%s/%s) already exists in subnet %s", ipamIP.Status.Reserved.String(),
+					ipamIP.Namespace, ipamIP.Name, ipamIP.Spec.Subnet.Name)
 				k.applySubnetLabel(ipamIP)
 			}
 			// break at first subnet match, there can be only one
@@ -156,11 +161,14 @@ func (k K8sClient) prepareCreateIpamIP(subnetName string, macKey string) (*ipamv
 		for _, existingIpamIP := range ipList.Items {
 			if existingIpamIP.Spec.Subnet.Name != subnetName {
 				// IP with that MAC is assigned to a different subnet (v4 vs v6?)
-				log.Debugf("IPAM IP with MAC %v and wrong subnet %s/%s found, ignoring", macKey, existingIpamIP.Namespace, existingIpamIP.Spec.Subnet.Name)
+				log.Debugf("IPAM IP with MAC %v and wrong subnet %s/%s found, ignoring", macKey,
+					existingIpamIP.Namespace, existingIpamIP.Spec.Subnet.Name)
 				continue
 			} else if existingIpamIP.Status.State == ipamv1alpha1.CFailedIPState {
-				log.Infof("Failed IP %s/%s in subnet %s found, deleting", existingIpamIP.Namespace, existingIpamIP.Name, existingIpamIP.Spec.Subnet.Name)
-				log.Debugf("Deleting old IP %s/%s:\n%v", existingIpamIP.Namespace, existingIpamIP.Name, prettyFormat(existingIpamIP.Status))
+				log.Infof("Failed IP %s/%s in subnet %s found, deleting", existingIpamIP.Namespace,
+					existingIpamIP.Name, existingIpamIP.Spec.Subnet.Name)
+				log.Debugf("Deleting old IP %s/%s:\n%v", existingIpamIP.Namespace, existingIpamIP.Name,
+					prettyFormat(existingIpamIP.Status))
 				err = k.Client.Delete(k.Ctx, &existingIpamIP)
 				if err != nil {
 					return nil, fmt.Errorf("failed to delete IP %s/%s: %w", existingIpamIP.Namespace, existingIpamIP.Name, err)
@@ -172,7 +180,8 @@ func (k K8sClient) prepareCreateIpamIP(subnetName string, macKey string) (*ipamv
 				}
 
 				k.EventRecorder.Eventf(&existingIpamIP, corev1.EventTypeNormal, "Deleted", "Deleted old IPAM IP")
-				log.Debugf("Old IP %s/%s deleted from subnet %s", existingIpamIP.Namespace, existingIpamIP.Name, existingIpamIP.Spec.Subnet.Name)
+				log.Debugf("Old IP %s/%s deleted from subnet %s", existingIpamIP.Namespace,
+					existingIpamIP.Name, existingIpamIP.Spec.Subnet.Name)
 			} else {
 				// IP already exists
 				return &existingIpamIP, nil
@@ -183,7 +192,11 @@ func (k K8sClient) prepareCreateIpamIP(subnetName string, macKey string) (*ipamv
 	return nil, nil
 }
 
-func (k K8sClient) doCreateIpamIP(subnetName string, macKey string, ipaddr net.IP, exactIP bool) (*ipamv1alpha1.IP, error) {
+func (k K8sClient) doCreateIpamIP(
+	subnetName string,
+	macKey string,
+	ipaddr net.IP,
+	exactIP bool) (*ipamv1alpha1.IP, error) {
 	oobLabelKey := strings.Split(k.OobLabel, "=")[0]
 	oobLabelValue := strings.Split(k.OobLabel, "=")[1]
 	var ipamIP *ipamv1alpha1.IP
@@ -236,7 +249,8 @@ func (k K8sClient) doCreateIpamIP(subnetName string, macKey string, ipaddr net.I
 		if err != nil {
 			return nil, fmt.Errorf("failed to create IP %s/%s: %w", ipamIP.Namespace, ipamIP.Name, err)
 		} else {
-			log.Infof("New IP %s (%s/%s) created in subnet %s", ipamIP.Status.Reserved.String(), ipamIP.Namespace, ipamIP.Name, ipamIP.Spec.Subnet.Name)
+			log.Infof("New IP %s (%s/%s) created in subnet %s", ipamIP.Status.Reserved.String(),
+				ipamIP.Namespace, ipamIP.Name, ipamIP.Spec.Subnet.Name)
 			k.EventRecorder.Eventf(ipamIP, corev1.EventTypeNormal, "Created", "Created IPAM IP")
 
 			// update IP attributes

--- a/plugins/oob/plugin.go
+++ b/plugins/oob/plugin.go
@@ -37,7 +37,8 @@ const (
 
 func parseArgs(args ...string) (string, string, error) {
 	if len(args) < 2 {
-		return "", "", fmt.Errorf("at least two arguments must be passed to ipam plugin, a namespace and a OOB subnet label, got %d", len(args))
+		return "", "", fmt.Errorf("at least two arguments must be passed to ipam plugin, a namespace and a "+
+			"OOB subnet label, got %d", len(args))
 	}
 
 	namespace := args[0]

--- a/plugins/pxeboot/plugin_test.go
+++ b/plugins/pxeboot/plugin_test.go
@@ -327,7 +327,10 @@ func TestTFTPNotRequested6(t *testing.T) {
 func TestPXERequested4(t *testing.T) {
 	Init4()
 
-	req, err := dhcpv4.NewDiscovery(net.HardwareAddr{0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff}, dhcpv4.WithRequestedOptions(dhcpv4.OptionBootfileName))
+	req, err := dhcpv4.NewDiscovery(net.HardwareAddr{
+		0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff},
+		dhcpv4.WithRequestedOptions(dhcpv4.OptionBootfileName),
+	)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -358,7 +361,10 @@ func TestPXERequested4(t *testing.T) {
 func TestTFTPRequested4(t *testing.T) {
 	Init4()
 
-	req, err := dhcpv4.NewDiscovery(net.HardwareAddr{0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff}, dhcpv4.WithRequestedOptions(dhcpv4.OptionBootfileName))
+	req, err := dhcpv4.NewDiscovery(net.HardwareAddr{
+		0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff},
+		dhcpv4.WithRequestedOptions(dhcpv4.OptionBootfileName),
+	)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -396,7 +402,10 @@ func TestTFTPRequested4(t *testing.T) {
 func TestPXENotRequested4(t *testing.T) {
 	Init4()
 
-	req, err := dhcpv4.NewDiscovery(net.HardwareAddr{0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff}, dhcpv4.WithRequestedOptions(dhcpv4.OptionBootfileName))
+	req, err := dhcpv4.NewDiscovery(net.HardwareAddr{
+		0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff},
+		dhcpv4.WithRequestedOptions(dhcpv4.OptionBootfileName),
+	)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -424,7 +433,10 @@ func TestPXENotRequested4(t *testing.T) {
 func TestTFTPNotRequested4(t *testing.T) {
 	Init4()
 
-	req, err := dhcpv4.NewDiscovery(net.HardwareAddr{0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff}, dhcpv4.WithRequestedOptions(dhcpv4.OptionBootfileName))
+	req, err := dhcpv4.NewDiscovery(net.HardwareAddr{
+		0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff},
+		dhcpv4.WithRequestedOptions(dhcpv4.OptionBootfileName),
+	)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -456,7 +468,10 @@ func TestTFTPNotRequested4(t *testing.T) {
 func TestWrongPXERequested4(t *testing.T) {
 	Init4()
 
-	req, err := dhcpv4.NewDiscovery(net.HardwareAddr{0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff}, dhcpv4.WithRequestedOptions(dhcpv4.OptionBootfileName))
+	req, err := dhcpv4.NewDiscovery(net.HardwareAddr{
+		0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff},
+		dhcpv4.WithRequestedOptions(dhcpv4.OptionBootfileName),
+	)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -487,7 +502,10 @@ func TestWrongPXERequested4(t *testing.T) {
 func TestWrongTFTPRequested4(t *testing.T) {
 	Init4()
 
-	req, err := dhcpv4.NewDiscovery(net.HardwareAddr{0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff}, dhcpv4.WithRequestedOptions(dhcpv4.OptionBootfileName))
+	req, err := dhcpv4.NewDiscovery(net.HardwareAddr{
+		0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff},
+		dhcpv4.WithRequestedOptions(dhcpv4.OptionBootfileName),
+	)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
# Proposed Changes

- Add `breaking` labeling to release drafter configuration.
- Add `golangci-lint` configuration