### PR TITLE
Re-enable arm builds

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -19,7 +19,7 @@ permissions:
   packages: write
 
 env:
-  platforms: linux/amd64
+  platforms: linux/amd64,linux/arm64
   registry: ghcr.io
   image: ghcr.io/${{ github.repository_owner }}/fedhcp
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,11 +33,11 @@ RUN apt-get update \
 FROM gcr.io/distroless/base-debian12 AS distroless-base
 
 FROM distroless-base AS distroless-amd64
-ENV LIB_DIR_PREFIX x86_64
+ENV LIB_DIR_PREFIX=x86_64
 ENV LINKER=ld-linux-x86-64.so.2
 
 FROM distroless-base AS distroless-arm64
-ENV LIB_DIR_PREFIX aarch64
+ENV LIB_DIR_PREFIX=aarch64
 ENV LINKER=ld-linux-aarch64.so.1
 
 FROM distroless-$TARGETARCH AS output-image

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,15 +30,23 @@ RUN apt-get update \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 
-FROM gcr.io/distroless/static-debian12
+FROM gcr.io/distroless/base-debian12 as distroless-base
+
+FROM distroless-base AS distroless-amd64
+ENV LIB_DIR_PREFIX x86_64
+
+FROM distroless-base AS distroless-arm64
+ENV LIB_DIR_PREFIX aarch64
+
+FROM distroless-$TARGETARCH AS output-image
 
 WORKDIR /
 
 COPY --from=builder /workspace/fedhcp .
 COPY --from=installer /sbin/setcap /sbin/setcap
-COPY --from=installer /lib/x86_64-linux-gnu/libcap.so.2 /lib/x86_64-linux-gnu/libcap.so.2
-COPY --from=installer /lib/x86_64-linux-gnu/libc.so.6 /lib/x86_64-linux-gnu/libc.so.6
-COPY --from=installer /lib64/ld-linux-x86-64.so.2 /lib64/ld-linux-x86-64.so.2
+COPY --from=installer /lib/${LIB_DIR_PREFIX}-linux-gnu/libcap.so.2 /lib/${LIB_DIR_PREFIX}-linux-gnu/libcap.so.2
+COPY --from=installer /lib/${LIB_DIR_PREFIX}-linux-gnu/libc.so.6 /lib/${LIB_DIR_PREFIX}-linux-gnu/libc.so.6
+COPY --from=installer /lib/${LIB_DIR_PREFIX}-linux-gnu/ld-linux-x86-64.so.2 /lib/${LIB_DIR_PREFIX}-linux-gnu/ld-linux-x86-64.so.2
 COPY --from=installer /bin/sh /bin/sh
 
 RUN /sbin/setcap 'cap_net_bind_service,cap_net_raw=+ep' /fedhcp

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,14 +23,14 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg \
     CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH GO111MODULE=on go build -ldflags="-s -w" -a -o fedhcp main.go
 
-FROM debian:stable as installer
+FROM debian:stable AS installer
 
 RUN apt-get update \
   && apt-get -y install --no-install-recommends libcap2-bin \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 
-FROM gcr.io/distroless/base-debian12 as distroless-base
+FROM gcr.io/distroless/base-debian12 AS distroless-base
 
 FROM distroless-base AS distroless-amd64
 ENV LIB_DIR_PREFIX x86_64

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,9 +34,11 @@ FROM gcr.io/distroless/base-debian12 as distroless-base
 
 FROM distroless-base AS distroless-amd64
 ENV LIB_DIR_PREFIX x86_64
+ENV LINKER=ld-linux-x86-64.so.2
 
 FROM distroless-base AS distroless-arm64
 ENV LIB_DIR_PREFIX aarch64
+ENV LINKER=ld-linux-aarch64.so.1
 
 FROM distroless-$TARGETARCH AS output-image
 
@@ -46,7 +48,7 @@ COPY --from=builder /workspace/fedhcp .
 COPY --from=installer /sbin/setcap /sbin/setcap
 COPY --from=installer /lib/${LIB_DIR_PREFIX}-linux-gnu/libcap.so.2 /lib/${LIB_DIR_PREFIX}-linux-gnu/libcap.so.2
 COPY --from=installer /lib/${LIB_DIR_PREFIX}-linux-gnu/libc.so.6 /lib/${LIB_DIR_PREFIX}-linux-gnu/libc.so.6
-COPY --from=installer /lib/${LIB_DIR_PREFIX}-linux-gnu/ld-linux-x86-64.so.2 /lib/${LIB_DIR_PREFIX}-linux-gnu/ld-linux-x86-64.so.2
+COPY --from=installer /lib/${LIB_DIR_PREFIX}-linux-gnu/${LINKER} /lib/${LIB_DIR_PREFIX}-linux-gnu/${LINKER}
 COPY --from=installer /bin/sh /bin/sh
 
 RUN /sbin/setcap 'cap_net_bind_service,cap_net_raw=+ep' /fedhcp


### PR DESCRIPTION
# Proposed Changes
We no longer support `range` plugin (and thus do not need `CGO` support), so let us re-enable ARM builds again

Fixes https://github.com/ironcore-dev/FeDHCP/issues/144