### PR TITLE
Switch `OOB` plugin to new kubernetes client initialization

### DIFF
--- a/internal/kubernetes/client.go
+++ b/internal/kubernetes/client.go
@@ -5,6 +5,7 @@ package kubernetes
 
 import (
 	"fmt"
+
 	"k8s.io/client-go/kubernetes/scheme"
 
 	ipamv1alpha1 "github.com/ironcore-dev/ipam/api/ipam/v1alpha1"

--- a/internal/kubernetes/client.go
+++ b/internal/kubernetes/client.go
@@ -5,10 +5,10 @@ package kubernetes
 
 import (
 	"fmt"
+	"k8s.io/client-go/kubernetes/scheme"
 
 	ipamv1alpha1 "github.com/ironcore-dev/ipam/api/ipam/v1alpha1"
 	metalv1alpha1 "github.com/ironcore-dev/metal-operator/api/v1alpha1"
-	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -16,20 +16,19 @@ import (
 )
 
 var (
-	scheme     = runtime.NewScheme()
 	kubeClient client.Client
 	cfg        *rest.Config
 )
 
 func init() {
-	utilruntime.Must(ipamv1alpha1.AddToScheme(scheme))
-	utilruntime.Must(metalv1alpha1.AddToScheme(scheme))
+	utilruntime.Must(ipamv1alpha1.AddToScheme(scheme.Scheme))
+	utilruntime.Must(metalv1alpha1.AddToScheme(scheme.Scheme))
 }
 
 func InitClient() error {
 	cfg = config.GetConfigOrDie()
 	var err error
-	kubeClient, err = client.New(cfg, client.Options{Scheme: scheme})
+	kubeClient, err = client.New(cfg, client.Options{})
 	if err != nil {
 		return fmt.Errorf("failed to create controller runtime client: %w", err)
 	}

--- a/plugins/oob/k8s.go
+++ b/plugins/oob/k8s.go
@@ -12,6 +12,8 @@ import (
 	"reflect"
 	"strings"
 
+	"github.com/ironcore-dev/fedhcp/internal/kubernetes"
+
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/watch"
 
@@ -24,7 +26,6 @@ import (
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/client/config"
 )
 
 const (
@@ -41,16 +42,8 @@ type K8sClient struct {
 }
 
 func NewK8sClient(namespace string, oobLabel string) (*K8sClient, error) {
-
-	if err := ipamv1alpha1.AddToScheme(scheme.Scheme); err != nil {
-		return nil, fmt.Errorf("unable to add registered types ipam to client scheme %w", err)
-	}
-
-	cfg := config.GetConfigOrDie()
-	cl, err := client.New(cfg, client.Options{})
-	if err != nil {
-		return nil, fmt.Errorf("failed to create controller runtime client %w", err)
-	}
+	cfg := kubernetes.GetConfig()
+	cl := kubernetes.GetClient()
 
 	clientset, err := ipam.NewForConfig(cfg)
 	if err != nil {


### PR DESCRIPTION
Also use `kubernetes scheme` for adding the scheme, otherwise we get:

```E1223 11:37:24.587887       1 event.go:442] "Could not construct reference, will not report event" err="no kind is registered for the type v1alpha1.IP in scheme \"pkg/runtime/scheme.go:100\"" object={"metadata":{"name":"2a10-afc0-e013-1001-0000-0000-1019-0002-fedhcp","namespace":"oob","uid":"65244fd7-1d4c-4eb0-b116-7dea224a34b9","resourceVersion":"362654819","generation":1,"creationTimestamp":"2024-12-23T11:37:24Z","labels":{"ip":"2a10-afc0-e013-1001-0000-0000-1019-0002","mac":"1c34d
a573a20","origin":"fedhcp"},"managedFields":[{"manager":"fedhcp","operation":"Update","apiVersion":"ipam.metal.ironcore.dev/v1alpha1","time":"2024-12-23T11:37:24Z","fieldsType":"FieldsV1","fieldsV1":{"f:metadata":{"f:labels":{".":{},"f:ip":{},"f:mac":{},"f:origin":{}}},"f:spec":{".":{},"f:ip":{},"f:subnet":{}}}}]},"spec":{"subnet":{"name":"spine-1-south"},"ip":"2a10:afc0:e013:1001::1019:2"},"status":{}} eventType="Normal" reason="Created" message="Created IPAM IP"
```