### PR TITLE
Fix unknown plugin for macfilter

### DIFF
--- a/main.go
+++ b/main.go
@@ -34,6 +34,7 @@ import (
 	"github.com/ironcore-dev/fedhcp/plugins/bluefield"
 	"github.com/ironcore-dev/fedhcp/plugins/httpboot"
 	"github.com/ironcore-dev/fedhcp/plugins/ipam"
+	"github.com/ironcore-dev/fedhcp/plugins/macfilter"
 	"github.com/ironcore-dev/fedhcp/plugins/metal"
 	"github.com/ironcore-dev/fedhcp/plugins/onmetal"
 	"github.com/ironcore-dev/fedhcp/plugins/oob"
@@ -64,6 +65,7 @@ var desiredPlugins = []*plugins.Plugin{
 	&pxeboot.Plugin,
 	&httpboot.Plugin,
 	&metal.Plugin,
+	&macfilter.Plugin,
 }
 
 var (


### PR DESCRIPTION
Starting with `macfilter` plugin configured fails with "unknown plugin":

![image](https://github.com/user-attachments/assets/59facfeb-711d-4d03-ba24-3e044a2309ec)
