### PR TITLE
Remove hard-coded server ID

### DIFF
--- a/plugins/bluefield/plugin.go
+++ b/plugins/bluefield/plugin.go
@@ -15,7 +15,6 @@ import (
 	"github.com/coredhcp/coredhcp/logger"
 	"github.com/coredhcp/coredhcp/plugins"
 	"github.com/insomniacslk/dhcp/dhcpv6"
-	"github.com/insomniacslk/dhcp/iana"
 	"github.com/ironcore-dev/fedhcp/internal/api"
 	"gopkg.in/yaml.v2"
 )
@@ -69,7 +68,7 @@ func setupPlugin(args ...string) (handler.Handler6, error) {
 	return handleDHCPv6, nil
 }
 
-func handleDHCPv6(req, resp dhcpv6.DHCPv6) (dhcpv6.DHCPv6, bool) { //nolint:staticcheck
+func handleDHCPv6(req, resp dhcpv6.DHCPv6) (dhcpv6.DHCPv6, bool) {
 	if req == nil {
 		log.Error("Received nil IPv6 request")
 		return nil, true
@@ -83,64 +82,44 @@ func handleDHCPv6(req, resp dhcpv6.DHCPv6) (dhcpv6.DHCPv6, bool) { //nolint:stat
 		return nil, true
 	}
 
-	hwaddr, err := net.ParseMAC("00:11:22:33:44:55")
-	if err != nil {
-		return nil, true
-	}
-
-	v6ServerID := &dhcpv6.DUIDLL{
-		HWType:        iana.HWTypeEthernet,
-		LinkLayerAddr: hwaddr,
-	}
-
-	switch m.Type() {
-	case dhcpv6.MessageTypeSolicit:
-		resp, err := dhcpv6.NewAdvertiseFromSolicit(m)
-		if err != nil {
-			log.Errorf("Failed to create DHCPv6 advertise: %v", err)
-			return nil, true
+	if m.Options.OneIANA() != nil {
+		switch m.Type() {
+		case dhcpv6.MessageTypeSolicit:
+			if resp == nil {
+				resp, err = dhcpv6.NewAdvertiseFromSolicit(m)
+				if err != nil {
+					log.Errorf("Failed to create DHCPv6 advertise: %v", err)
+					return nil, true
+				}
+			}
+			addOptIANA(resp, m.Options.OneIANA().IaId)
+		case dhcpv6.MessageTypeRequest:
+			if resp == nil {
+				resp, err = dhcpv6.NewReplyFromMessage(m)
+				if err != nil {
+					log.Errorf("Failed to create DHCPv6 reply: %v", err)
+					return nil, true
+				}
+			}
+			addOptIANA(resp, m.Options.OneIANA().IaId)
 		}
-
-		log.Infof("IP: %s", ipaddr)
-
-		resp.AddOption(&dhcpv6.OptIANA{
-			IaId: m.Options.OneIANA().IaId,
-			T1:   1 * time.Hour,
-			T2:   2 * time.Hour,
-			Options: dhcpv6.IdentityOptions{Options: []dhcpv6.Option{
-				&dhcpv6.OptIAAddress{
-					IPv6Addr:          ipaddr,
-					PreferredLifetime: 24 * time.Hour,
-					ValidLifetime:     48 * time.Hour,
-				},
-			}},
-		})
-
-		dhcpv6.WithServerID(v6ServerID)(resp)
-		return resp, false
-
-	case dhcpv6.MessageTypeRequest:
-		resp, err = dhcpv6.NewReplyFromMessage(m) //nolint:staticcheck
-		if err != nil {
-			log.Errorf("Failed to create DHCPv6 reply: %v", err)
-			return nil, false
-		}
-
-		resp.AddOption(&dhcpv6.OptIANA{
-			IaId: m.Options.OneIANA().IaId,
-			T1:   1 * time.Hour,
-			T2:   2 * time.Hour,
-			Options: dhcpv6.IdentityOptions{Options: []dhcpv6.Option{
-				&dhcpv6.OptIAAddress{
-					IPv6Addr:          ipaddr,
-					PreferredLifetime: 24 * time.Hour,
-					ValidLifetime:     48 * time.Hour,
-				},
-			}},
-		})
-
-		dhcpv6.WithServerID(v6ServerID)(resp)
-		return resp, true
 	}
-	return nil, false
+
+	return resp, false
+}
+
+func addOptIANA(resp dhcpv6.DHCPv6, iaId [4]byte) {
+	resp.AddOption(&dhcpv6.OptIANA{
+		IaId: iaId,
+		T1:   1 * time.Hour,
+		T2:   2 * time.Hour,
+		Options: dhcpv6.IdentityOptions{Options: []dhcpv6.Option{
+			&dhcpv6.OptIAAddress{
+				IPv6Addr:          ipaddr,
+				PreferredLifetime: 24 * time.Hour,
+				ValidLifetime:     48 * time.Hour,
+			},
+		}},
+	})
+	log.Infof("Added option IANA, address %s", ipaddr)
 }

--- a/plugins/bluefield/plugin_test.go
+++ b/plugins/bluefield/plugin_test.go
@@ -103,7 +103,7 @@ var _ = Describe("Bluefield Plugin", func() {
 		Context("when handling Request messages", func() {
 			It("should respond with a Reply message", func() {
 				resp, stop := handleDHCPv6(createRequestMessage(), nil)
-				Expect(stop).To(BeTrue())
+				Expect(stop).To(BeFalse())
 
 				respm, err := resp.GetInnerMessage()
 				Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
Do not recreate the response, use the one from the `coredhcp` handling procedure.

Add guards to protect against null pointer

Refactor for readability and unified debug output

Fixes #324 