### PR TITLE
Enhance MAC address detection for `metal` plugin

### DIFF
--- a/plugins/metal/plugin.go
+++ b/plugins/metal/plugin.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/ironcore-dev/fedhcp/internal/helper"
 	"github.com/ironcore-dev/fedhcp/internal/printer"
 
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -29,7 +30,6 @@ import (
 	"github.com/ironcore-dev/fedhcp/internal/kubernetes"
 	ipamv1alpha1 "github.com/ironcore-dev/ipam/api/ipam/v1alpha1"
 	metalv1alpha1 "github.com/ironcore-dev/metal-operator/api/v1alpha1"
-	"github.com/mdlayher/netx/eui64"
 	"gopkg.in/yaml.v3"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -159,9 +159,9 @@ func handler6(req, resp dhcpv6.DHCPv6) (dhcpv6.DHCPv6, bool) {
 	}
 
 	relayMsg := req.(*dhcpv6.RelayMessage)
-	_, mac, err := eui64.ParseIP(relayMsg.PeerAddr)
+	mac, err := helper.GetMAC(relayMsg, log)
 	if err != nil {
-		log.Errorf("Could not parse peer address %s: %s", relayMsg.PeerAddr.String(), err)
+		log.Errorf("Failed to obtain MAC, dropping.")
 		return nil, true
 	}
 

--- a/plugins/metal/suite_test.go
+++ b/plugins/metal/suite_test.go
@@ -82,7 +82,7 @@ var _ = BeforeSuite(func() {
 		// Note that you must have the required binaries setup under the bin directory to perform
 		// the tests directly. When we run make test it will be setup and used automatically.
 		BinaryAssetsDirectory: filepath.Join("..", "..", "bin", "k8s",
-			fmt.Sprintf("1.30.0-%s-%s", runtime.GOOS, runtime.GOARCH)),
+			fmt.Sprintf("1.34.0-%s-%s", runtime.GOOS, runtime.GOARCH)),
 	}
 
 	var err error

--- a/plugins/oob/plugin.go
+++ b/plugins/oob/plugin.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/ironcore-dev/fedhcp/internal/helper"
 	"github.com/ironcore-dev/fedhcp/internal/printer"
 
 	"github.com/ironcore-dev/fedhcp/internal/api"
@@ -23,7 +24,6 @@ import (
 	"github.com/coredhcp/coredhcp/plugins"
 	"github.com/insomniacslk/dhcp/dhcpv4"
 	"github.com/insomniacslk/dhcp/dhcpv6"
-	"github.com/insomniacslk/dhcp/iana"
 
 	"github.com/mdlayher/netx/eui64"
 )
@@ -105,7 +105,7 @@ func handler6(req, resp dhcpv6.DHCPv6) (dhcpv6.DHCPv6, bool) {
 
 	relayMsg := req.(*dhcpv6.RelayMessage)
 
-	mac, err := getMAC(relayMsg)
+	mac, err := helper.GetMAC(relayMsg, log)
 	if err != nil {
 		log.Errorf("Failed to obtain MAC, dropping.")
 		return nil, true
@@ -158,22 +158,6 @@ func handler6(req, resp dhcpv6.DHCPv6) (dhcpv6.DHCPv6, bool) {
 	log.Infof("Client %s: added option IA address %s", macKey, iana.String())
 
 	return resp, false
-}
-
-func getMAC(relayMsg *dhcpv6.RelayMessage) (net.HardwareAddr, error) {
-	hwType, mac := relayMsg.Options.ClientLinkLayerAddress()
-	if hwType == iana.HWTypeEthernet {
-		return mac, nil
-	}
-
-	log.Infof("failed to retrieve client link layer address, falling back to EUI64 (%s)", relayMsg.PeerAddr.String())
-	_, mac, err := eui64.ParseIP(relayMsg.PeerAddr)
-	if err != nil {
-		log.Errorf("Could not parse peer address: %s", err)
-		return nil, err
-	}
-
-	return mac, nil
 }
 
 func setup4(args ...string) (handler.Handler4, error) {


### PR DESCRIPTION
Improve MAC detection to use ClientLinkLayerAddress after RFC6939

Fixes https://github.com/ironcore-dev/FeDHCP/issues/374