### PR TITLE
Enhance the ztp plugin and add a new ONIE boot plugin

### DIFF
--- a/example/onie_config.yaml
+++ b/example/onie_config.yaml
@@ -1,0 +1,1 @@
+onieImagesAddress: "http://[2001:db8::1]:8086/onie"

--- a/example/ztp_config.yaml
+++ b/example/ztp_config.yaml
@@ -1,9 +1,16 @@
+provisioningScriptAddress: "http://[2001:db8::1]/ztp/provisioning.sh"
+
 switches:
   - macAddress: aa:bb:cc:dd:ee:ff
-    provisioningScriptAddress: "http://[2001:db8::1]/ztp/provision-spine.sh"
     name: spine-1
   - macAddress: 00:11:22:33:44:55
     provisioningScriptAddress: "http://[2001:db8::1]/ztp/provision-leaf.sh"
     name: leaf-1
   - macAddress: 00:11:22:33:44:66
-    provisioningScriptAddress: "http://[2001:db8::1]/ztp/provision-oob.sh"
+    name: oob-1
+
+onieInstallers:
+  - vendor: "onie_vendor:x86_64-accton_as7726_32x-r0"
+    installerURL: "http://[2001:db8::1]/onie/accton_as7726_32x.bin"
+  - vendor: "onie_vendor:x86_64-accton_as9516_32d-r0"
+    installerURL: "http://[2001:db8::1]/onie/accton_as9516_32d.bin"

--- a/example/ztp_config.yaml
+++ b/example/ztp_config.yaml
@@ -8,9 +8,3 @@ switches:
     name: leaf-1
   - macAddress: 00:11:22:33:44:66
     name: oob-1
-
-onieInstallers:
-  - vendor: "onie_vendor:x86_64-accton_as7726_32x-r0"
-    installerURL: "http://[2001:db8::1]/onie/accton_as7726_32x.bin"
-  - vendor: "onie_vendor:x86_64-accton_as9516_32d-r0"
-    installerURL: "http://[2001:db8::1]/onie/accton_as9516_32d.bin"

--- a/internal/api/onie_config.go
+++ b/internal/api/onie_config.go
@@ -1,0 +1,8 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: MIT
+
+package api
+
+type ONIEConfig struct {
+	OnieImagesAddress string `yaml:"onieImagesAddress"`
+}

--- a/internal/api/ztp_config.go
+++ b/internal/api/ztp_config.go
@@ -4,11 +4,18 @@
 package api
 
 type ZTPConfig struct {
-	Switches []Switch `yaml:"switches"`
+	ProvisioningScriptAddress string          `yaml:"provisioningScriptAddress"`
+	Switches                  []Switch        `yaml:"switches"`
+	ONIEInstallers            []ONIEInstaller `yaml:"onieInstallers"`
 }
 
 type Switch struct {
 	MacAddress                string `yaml:"macAddress"`
 	ProvisioningScriptAddress string `yaml:"provisioningScriptAddress"`
 	Name                      string `yaml:"name"`
+}
+
+type ONIEInstaller struct {
+	Vendor       string `yaml:"vendor"`
+	InstallerURL string `yaml:"installerURL"`
 }

--- a/internal/api/ztp_config.go
+++ b/internal/api/ztp_config.go
@@ -4,18 +4,12 @@
 package api
 
 type ZTPConfig struct {
-	ProvisioningScriptAddress string          `yaml:"provisioningScriptAddress"`
-	Switches                  []Switch        `yaml:"switches"`
-	ONIEInstallers            []ONIEInstaller `yaml:"onieInstallers"`
+	ProvisioningScriptAddress string   `yaml:"provisioningScriptAddress"`
+	Switches                  []Switch `yaml:"switches"`
 }
 
 type Switch struct {
 	MacAddress                string `yaml:"macAddress"`
 	ProvisioningScriptAddress string `yaml:"provisioningScriptAddress"`
 	Name                      string `yaml:"name"`
-}
-
-type ONIEInstaller struct {
-	Vendor       string `yaml:"vendor"`
-	InstallerURL string `yaml:"installerURL"`
 }

--- a/main.go
+++ b/main.go
@@ -39,6 +39,7 @@ import (
 	"github.com/ironcore-dev/fedhcp/plugins/macfilter"
 	"github.com/ironcore-dev/fedhcp/plugins/metal"
 	"github.com/ironcore-dev/fedhcp/plugins/ntp"
+	"github.com/ironcore-dev/fedhcp/plugins/onie"
 	"github.com/ironcore-dev/fedhcp/plugins/onmetal"
 	"github.com/ironcore-dev/fedhcp/plugins/oob"
 	"github.com/ironcore-dev/fedhcp/plugins/pxeboot"
@@ -74,6 +75,7 @@ var desiredPlugins = []*plugins.Plugin{
 	&metal.Plugin,
 	&ntp.Plugin,
 	&stateless.Plugin,
+	&onie.Plugin,
 	&ztp.Plugin,
 }
 

--- a/plugins/onie/plugin.go
+++ b/plugins/onie/plugin.go
@@ -1,0 +1,124 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: MIT
+
+package onie
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/ironcore-dev/fedhcp/internal/printer"
+
+	"github.com/ironcore-dev/fedhcp/internal/api"
+	"gopkg.in/yaml.v2"
+
+	"github.com/coredhcp/coredhcp/handler"
+	"github.com/coredhcp/coredhcp/logger"
+	"github.com/coredhcp/coredhcp/plugins"
+	"github.com/insomniacslk/dhcp/dhcpv6"
+)
+
+var log = logger.GetLogger("plugins/onie")
+
+// Plugin wraps plugin registration information
+var Plugin = plugins.Plugin{
+	Name:   "onie",
+	Setup6: setup6,
+}
+
+// onieImagesAddress is the base URL for ONIE installer images
+var onieImagesAddress string
+
+const (
+	onieUserClass = "onie_dhcp_user_class"
+)
+
+// args[0] = path to config file
+func parseArgs(args ...string) (string, error) {
+	if len(args) != 1 {
+		return "", fmt.Errorf("exactly one argument must be passed to the plugin, got %d", len(args))
+	}
+	return args[0], nil
+}
+
+func loadConfig(args ...string) (*api.ONIEConfig, error) {
+	path, err := parseArgs(args...)
+	if err != nil {
+		return nil, fmt.Errorf("invalid configuration: %v", err)
+	}
+
+	log.Debugf("Reading config file %s", path)
+	configData, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read config file: %v", err)
+	}
+
+	config := &api.ONIEConfig{}
+	if err = yaml.Unmarshal(configData, config); err != nil {
+		return nil, fmt.Errorf("failed to parse config file: %v", err)
+	}
+
+	return config, nil
+}
+
+func setup6(args ...string) (handler.Handler6, error) {
+	onieConfig, err := loadConfig(args...)
+	if err != nil {
+		return nil, err
+	}
+
+	if onieConfig.OnieImagesAddress == "" {
+		return nil, fmt.Errorf("onieImagesAddress must be set in the ONIE config")
+	}
+
+	onieImagesAddress = onieConfig.OnieImagesAddress
+	log.Printf("loaded ONIE plugin for DHCPv6 with images address: %s", onieImagesAddress)
+	return handler6, nil
+}
+
+func handler6(req, resp dhcpv6.DHCPv6) (dhcpv6.DHCPv6, bool) {
+	if req == nil {
+		log.Error("Received nil IPv6 request")
+		return nil, true
+	}
+
+	printer.VerboseRequest(req, log, printer.IPv6)
+	defer printer.VerboseResponse(req, resp, log, printer.IPv6)
+
+	if !req.IsRelay() {
+		log.Printf("Received non-relay DHCPv6 request. Dropping.")
+		return nil, true
+	}
+
+	m, err := req.GetInnerMessage()
+	if err != nil {
+		log.Errorf("could not decapsulate: %v", err)
+		return nil, true
+	}
+
+	if !isONIERequest(m) {
+		return resp, false
+	}
+
+	bf := dhcpv6.OptBootFileURL(onieImagesAddress)
+	resp.AddOption(bf)
+	log.Infof("Added ONIE BootFileURL option: %s", onieImagesAddress)
+
+	return resp, false
+}
+
+// isONIERequest checks whether the DHCPv6 message is an ONIE discovery request
+// by verifying that Boot File URL (option 59) is requested and UserClass contains
+// "onie_dhcp_user_class".
+func isONIERequest(m *dhcpv6.Message) bool {
+	if !m.IsOptionRequested(dhcpv6.OptionBootfileURL) {
+		return false
+	}
+	userClasses := m.Options.UserClasses()
+	for _, uc := range userClasses {
+		if string(uc) == onieUserClass {
+			return true
+		}
+	}
+	return false
+}

--- a/plugins/onie/plugin_test.go
+++ b/plugins/onie/plugin_test.go
@@ -1,0 +1,160 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: MIT
+
+package onie
+
+import (
+	"encoding/binary"
+	"net"
+
+	"github.com/mdlayher/netx/eui64"
+
+	"github.com/insomniacslk/dhcp/dhcpv6"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("ONIE Plugin", func() {
+	Describe("DHCPv6 ONIE Message Handling", func() {
+		It("should return Boot File URL for a valid ONIE request", func() {
+			req := createONIERequest(testMAC)
+
+			stub, err := dhcpv6.NewMessage()
+			stub.MessageType = dhcpv6.MessageTypeReply
+			Expect(err).NotTo(HaveOccurred())
+
+			resp, stop := handler6(req, stub)
+			Expect(stop).To(BeFalse())
+
+			bootFileURL := resp.(*dhcpv6.Message).Options.BootFileURL()
+			Expect(bootFileURL).To(Equal(testONIEImagesAddress))
+		})
+
+		It("should not return Boot File URL when Boot File URL is not in ORO", func() {
+			req := createONIERequestWithoutBootFileURL(testMAC)
+
+			stub, err := dhcpv6.NewMessage()
+			stub.MessageType = dhcpv6.MessageTypeReply
+			Expect(err).NotTo(HaveOccurred())
+
+			resp, stop := handler6(req, stub)
+			Expect(stop).To(BeFalse())
+
+			opts := resp.GetOption(dhcpv6.OptionBootfileURL)
+			Expect(opts).To(BeEmpty())
+		})
+
+		It("should not return Boot File URL when UserClass is missing", func() {
+			req := createONIERequestWithoutUserClass(testMAC)
+
+			stub, err := dhcpv6.NewMessage()
+			stub.MessageType = dhcpv6.MessageTypeReply
+			Expect(err).NotTo(HaveOccurred())
+
+			resp, stop := handler6(req, stub)
+			Expect(stop).To(BeFalse())
+
+			opts := resp.GetOption(dhcpv6.OptionBootfileURL)
+			Expect(opts).To(BeEmpty())
+		})
+
+		It("should drop non-relay DHCPv6 requests", func() {
+			req, err := dhcpv6.NewMessage()
+			Expect(err).NotTo(HaveOccurred())
+			req.MessageType = dhcpv6.MessageTypeRequest
+			req.AddOption(dhcpv6.OptRequestedOption(dhcpv6.OptionBootfileURL))
+
+			stub, err := dhcpv6.NewMessage()
+			stub.MessageType = dhcpv6.MessageTypeReply
+			Expect(err).NotTo(HaveOccurred())
+
+			resp, stop := handler6(req, stub)
+			Expect(stop).To(BeTrue())
+			Expect(resp).To(BeNil())
+		})
+	})
+})
+
+func createONIERequest(mac string) dhcpv6.DHCPv6 {
+	hwAddr, err := net.ParseMAC(mac)
+	Expect(err).NotTo(HaveOccurred())
+
+	i := net.ParseIP(linkLocalIPV6Prefix)
+	linkLocalIPV6Addr, err := eui64.ParseMAC(i, hwAddr)
+	Expect(err).NotTo(HaveOccurred())
+
+	req, err := dhcpv6.NewMessage()
+	Expect(err).NotTo(HaveOccurred())
+	req.MessageType = dhcpv6.MessageTypeRequest
+
+	// Request Boot File URL (option 59)
+	req.AddOption(dhcpv6.OptRequestedOption(dhcpv6.OptionBootfileURL))
+
+	// Add UserClass with "onie_dhcp_user_class"
+	addONIEUserClass(req)
+
+	relayedRequest, err := dhcpv6.EncapsulateRelay(req, dhcpv6.MessageTypeRelayForward,
+		net.ParseIP("2001:db8:1111:2222:3333:4444:5555:6666"), linkLocalIPV6Addr)
+	Expect(err).NotTo(HaveOccurred())
+
+	return relayedRequest
+}
+
+func createONIERequestWithoutBootFileURL(mac string) dhcpv6.DHCPv6 {
+	hwAddr, err := net.ParseMAC(mac)
+	Expect(err).NotTo(HaveOccurred())
+
+	i := net.ParseIP(linkLocalIPV6Prefix)
+	linkLocalIPV6Addr, err := eui64.ParseMAC(i, hwAddr)
+	Expect(err).NotTo(HaveOccurred())
+
+	req, err := dhcpv6.NewMessage()
+	Expect(err).NotTo(HaveOccurred())
+	req.MessageType = dhcpv6.MessageTypeRequest
+
+	// Do NOT request Boot File URL
+	req.AddOption(dhcpv6.OptRequestedOption(dhcpv6.OptionDNSRecursiveNameServer))
+
+	addONIEUserClass(req)
+
+	relayedRequest, err := dhcpv6.EncapsulateRelay(req, dhcpv6.MessageTypeRelayForward,
+		net.ParseIP("2001:db8:1111:2222:3333:4444:5555:6666"), linkLocalIPV6Addr)
+	Expect(err).NotTo(HaveOccurred())
+
+	return relayedRequest
+}
+
+func createONIERequestWithoutUserClass(mac string) dhcpv6.DHCPv6 {
+	hwAddr, err := net.ParseMAC(mac)
+	Expect(err).NotTo(HaveOccurred())
+
+	i := net.ParseIP(linkLocalIPV6Prefix)
+	linkLocalIPV6Addr, err := eui64.ParseMAC(i, hwAddr)
+	Expect(err).NotTo(HaveOccurred())
+
+	req, err := dhcpv6.NewMessage()
+	Expect(err).NotTo(HaveOccurred())
+	req.MessageType = dhcpv6.MessageTypeRequest
+
+	// Request Boot File URL but no UserClass
+	req.AddOption(dhcpv6.OptRequestedOption(dhcpv6.OptionBootfileURL))
+
+	relayedRequest, err := dhcpv6.EncapsulateRelay(req, dhcpv6.MessageTypeRelayForward,
+		net.ParseIP("2001:db8:1111:2222:3333:4444:5555:6666"), linkLocalIPV6Addr)
+	Expect(err).NotTo(HaveOccurred())
+
+	return relayedRequest
+}
+
+func addONIEUserClass(req *dhcpv6.Message) {
+	userClassData := []byte(onieUserClass)
+	buf := make([]byte, 2+len(userClassData))
+	binary.BigEndian.PutUint16(buf[0:2], uint16(len(userClassData)))
+	copy(buf[2:], userClassData)
+
+	optUserClass := dhcpv6.OptUserClass{}
+	err := optUserClass.FromBytes(buf)
+	Expect(err).NotTo(HaveOccurred())
+	req.UpdateOption(&optUserClass)
+}

--- a/plugins/onie/suite_test.go
+++ b/plugins/onie/suite_test.go
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and IronCore contributors
 // SPDX-License-Identifier: MIT
 
-package ztp
+package onie
 
 import (
 	"os"
@@ -15,30 +15,26 @@ import (
 	. "github.com/onsi/gomega"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
-	//+kubebuilder:scaffold:imports
 )
 
 const (
-	pollingInterval               = 50 * time.Millisecond
-	eventuallyTimeout             = 3 * time.Second
-	consistentlyDuration          = 1 * time.Second
-	testConfigPath                = "config.yaml"
-	testZtpProvisioningScriptPath = "https://[2001:db8::1]/ztp/provisioning.sh"
-	testZtpOverrideScriptPath     = "https://[2001:db8::1]/ztp/provision-override.sh"
-	linkLocalIPV6Prefix           = "fe80::"
-	inventoryMAC                  = "00:11:22:33:44:55"
-	inventoryMACWithOverride      = "00:11:22:33:44:66"
-	nonInventoryMAC               = "47:11:47:11:47:11"
+	pollingInterval       = 50 * time.Millisecond
+	eventuallyTimeout     = 3 * time.Second
+	consistentlyDuration  = 1 * time.Second
+	testConfigPath        = "config.yaml"
+	testONIEImagesAddress = "http://[2001:db8::1]:8086/onie"
+	linkLocalIPV6Prefix   = "fe80::"
+	testMAC               = "00:11:22:33:44:55"
 )
 
-func TestZTP(t *testing.T) {
+func TestONIE(t *testing.T) {
 	SetDefaultConsistentlyPollingInterval(pollingInterval)
 	SetDefaultEventuallyPollingInterval(pollingInterval)
 	SetDefaultEventuallyTimeout(eventuallyTimeout)
 	SetDefaultConsistentlyDuration(consistentlyDuration)
 	RegisterFailHandler(Fail)
 
-	RunSpecs(t, "ZTP Plugin Suite")
+	RunSpecs(t, "ONIE Plugin Suite")
 }
 
 var _ = BeforeSuite(func() {
@@ -46,19 +42,8 @@ var _ = BeforeSuite(func() {
 	log.Print("BeforeSuite: Runs once before all tests")
 
 	configFile := testConfigPath
-	config := &api.ZTPConfig{
-		ProvisioningScriptAddress: testZtpProvisioningScriptPath,
-		Switches: []api.Switch{
-			{
-				MacAddress: inventoryMAC,
-				Name:       "test-switch",
-			},
-			{
-				MacAddress:                inventoryMACWithOverride,
-				ProvisioningScriptAddress: testZtpOverrideScriptPath,
-				Name:                      "test-switch-override",
-			},
-		},
+	config := &api.ONIEConfig{
+		OnieImagesAddress: testONIEImagesAddress,
 	}
 	configData, err := yaml.Marshal(config)
 	Expect(err).NotTo(HaveOccurred())
@@ -72,5 +57,5 @@ var _ = BeforeSuite(func() {
 
 	_, err = setup6(file.Name())
 	Expect(err).NotTo(HaveOccurred())
-	Expect(inventory).To(HaveLen(2))
+	Expect(onieImagesAddress).To(Equal(testONIEImagesAddress))
 })

--- a/plugins/ztp/plugin.go
+++ b/plugins/ztp/plugin.go
@@ -4,12 +4,10 @@
 package ztp
 
 import (
-	"encoding/binary"
 	"fmt"
 	"net/url"
 	"os"
 
-	"github.com/ironcore-dev/fedhcp/internal/helper"
 	"github.com/ironcore-dev/fedhcp/internal/printer"
 
 	"github.com/mdlayher/netx/eui64"
@@ -37,14 +35,10 @@ var inventory SwitchInventory
 // globalProvisioningScriptAddress is the default ZTP script URL for all switches
 var globalProvisioningScriptAddress string
 
-// onieInstallers maps vendor class data strings to installer URLs
-var onieInstallers map[string]string
-
 type SwitchInventory []api.Switch
 
 const (
 	optionZTPCode = 239
-	onieUserClass = "onie_dhcp_user_class"
 )
 
 // args[0] = path to config file
@@ -116,18 +110,6 @@ func parseConfig(args ...string) error {
 		inventory = append(inventory, switchEntry)
 	}
 
-	// Parse ONIE installer mappings
-	onieInstallers = make(map[string]string)
-	for _, installer := range ztpConfig.ONIEInstallers {
-		if installer.Vendor == "" {
-			return fmt.Errorf("ONIE installer entry has empty vendor string")
-		}
-		if err := validateURL(installer.InstallerURL); err != nil {
-			return fmt.Errorf("invalid ONIE installer URL for vendor %s: %v", installer.Vendor, err)
-		}
-		onieInstallers[installer.Vendor] = installer.InstallerURL
-	}
-
 	return nil
 }
 
@@ -168,103 +150,12 @@ func handler6(req, resp dhcpv6.DHCPv6) (dhcpv6.DHCPv6, bool) {
 
 	relayMsg := req.(*dhcpv6.RelayMessage)
 
-	// Handle ONIE installer request
-	if isONIERequest(m) {
-		handleONIE(relayMsg, m, resp)
-	}
-
-	// Hanlde ZTP provisioning script request
+	// Handle ZTP provisioning script request
 	if m.IsOptionRequested(optionZTPCode) {
 		handleZTP(relayMsg, resp)
 	}
 
 	return resp, false
-}
-
-// isONIERequest checks whether the DHCPv6 message is an ONIE discovery request
-// by verifying that Boot File URL (option 59) is requested and UserClass contains
-// "onie_dhcp_user_class".
-func isONIERequest(m *dhcpv6.Message) bool {
-	if !m.IsOptionRequested(dhcpv6.OptionBootfileURL) {
-		return false
-	}
-	userClasses := m.Options.UserClasses()
-	for _, uc := range userClasses {
-		if string(uc) == onieUserClass {
-			return true
-		}
-	}
-	return false
-}
-
-// getVendorClassData extracts the vendor class data string from the DHCPv6 message.
-// ONIE sends VendorClass with EnterpriseNumber=xyz (4-bytes) and data like "onie_vendor:x86_64-accton_as7726_32x-r0".
-func getVendorClassData(m *dhcpv6.Message) string {
-	opt := m.GetOneOption(dhcpv6.OptionVendorClass)
-	if opt == nil {
-		return ""
-	}
-
-	// Parse raw bytes: uint32 enterprise number + (uint16 length + data)*
-	vcc := opt.ToBytes()
-	if len(vcc) < 6 {
-		return ""
-	}
-
-	entNum := binary.BigEndian.Uint32(vcc[0:4])
-	if entNum != 0 {
-		return ""
-	}
-
-	dataLen := int(binary.BigEndian.Uint16(vcc[4:6]))
-	if len(vcc) < 6+dataLen {
-		return ""
-	}
-
-	return string(vcc[6 : 6+dataLen])
-}
-
-func handleONIE(relayMsg *dhcpv6.RelayMessage, m *dhcpv6.Message, resp dhcpv6.DHCPv6) {
-	if len(onieInstallers) == 0 {
-		log.Debug("No ONIE installers configured")
-		return
-	}
-
-	mac, err := helper.GetMAC(relayMsg, log)
-	if err != nil {
-		log.Errorf("could not get MAC address: %v", err)
-		return
-	}
-
-	// Check MAC is in inventory
-	macFound := false
-	for _, switchEntry := range inventory {
-		if switchEntry.MacAddress == mac.String() {
-			macFound = true
-			log.Infof("ONIE request from known switch %s (MAC %s)", switchEntry.Name, mac.String())
-			break
-		}
-	}
-	if !macFound {
-		log.Infof("ONIE request from unknown MAC %s, ignoring", mac.String())
-		return
-	}
-
-	vendorClass := getVendorClassData(m)
-	if vendorClass == "" {
-		log.Warning("ONIE request has no vendor class data")
-		return
-	}
-
-	installerURL, ok := onieInstallers[vendorClass]
-	if !ok {
-		log.Warningf("No ONIE installer configured for vendor %q", vendorClass)
-		return
-	}
-
-	bf := dhcpv6.OptBootFileURL(installerURL)
-	resp.AddOption(bf)
-	log.Infof("Added ONIE BootFileURL option: %s (vendor: %s)", installerURL, vendorClass)
 }
 
 func handleZTP(relayMsg *dhcpv6.RelayMessage, resp dhcpv6.DHCPv6) {

--- a/plugins/ztp/plugin.go
+++ b/plugins/ztp/plugin.go
@@ -4,10 +4,12 @@
 package ztp
 
 import (
+	"encoding/binary"
 	"fmt"
 	"net/url"
 	"os"
 
+	"github.com/ironcore-dev/fedhcp/internal/helper"
 	"github.com/ironcore-dev/fedhcp/internal/printer"
 
 	"github.com/mdlayher/netx/eui64"
@@ -32,10 +34,17 @@ var Plugin = plugins.Plugin{
 // map MAC address to inventory name
 var inventory SwitchInventory
 
+// globalProvisioningScriptAddress is the default ZTP script URL for all switches
+var globalProvisioningScriptAddress string
+
+// onieInstallers maps vendor class data strings to installer URLs
+var onieInstallers map[string]string
+
 type SwitchInventory []api.Switch
 
 const (
 	optionZTPCode = 239
+	onieUserClass = "onie_dhcp_user_class"
 )
 
 // args[0] = path to config file
@@ -66,23 +75,57 @@ func loadConfig(args ...string) (*api.ZTPConfig, error) {
 	return config, nil
 }
 
+func validateURL(rawURL string) error {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return fmt.Errorf("invalid URL %q: %v", rawURL, err)
+	}
+	if (u.Scheme != "http" && u.Scheme != "https") || u.Host == "" || u.Path == "" {
+		return fmt.Errorf("malformed URL %q, should be a valid http(s) URL", rawURL)
+	}
+	return nil
+}
+
 func parseConfig(args ...string) error {
 	ztpConfig, err := loadConfig(args...)
 	if err != nil {
 		return err
 	}
 
+	// Validate global provisioning script address if set
+	if ztpConfig.ProvisioningScriptAddress != "" {
+		if err := validateURL(ztpConfig.ProvisioningScriptAddress); err != nil {
+			return fmt.Errorf("invalid global provisioning script address: %v", err)
+		}
+		globalProvisioningScriptAddress = ztpConfig.ProvisioningScriptAddress
+	}
+
 	for _, switchEntry := range ztpConfig.Switches {
-		scriptURL, err := url.Parse(switchEntry.ProvisioningScriptAddress)
-		if err != nil {
-			return fmt.Errorf("invalid ztp script scriptURL: %v", err)
+		// Resolve provisioning script address: per-switch override or global default
+		scriptAddr := switchEntry.ProvisioningScriptAddress
+		if scriptAddr == "" {
+			scriptAddr = globalProvisioningScriptAddress
 		}
 
-		if (scriptURL.Scheme != "http" && scriptURL.Scheme != "https") || scriptURL.Host == "" || scriptURL.Path == "" {
-			return fmt.Errorf("malformed ZTP script parameter, should be a valid URL")
+		if scriptAddr != "" {
+			if err := validateURL(scriptAddr); err != nil {
+				return fmt.Errorf("invalid ZTP script URL for switch %s: %v", switchEntry.Name, err)
+			}
 		}
 
 		inventory = append(inventory, switchEntry)
+	}
+
+	// Parse ONIE installer mappings
+	onieInstallers = make(map[string]string)
+	for _, installer := range ztpConfig.ONIEInstallers {
+		if installer.Vendor == "" {
+			return fmt.Errorf("ONIE installer entry has empty vendor string")
+		}
+		if err := validateURL(installer.InstallerURL); err != nil {
+			return fmt.Errorf("invalid ONIE installer URL for vendor %s: %v", installer.Vendor, err)
+		}
+		onieInstallers[installer.Vendor] = installer.InstallerURL
 	}
 
 	return nil
@@ -123,16 +166,112 @@ func handler6(req, resp dhcpv6.DHCPv6) (dhcpv6.DHCPv6, bool) {
 		return nil, true
 	}
 
-	if !m.IsOptionRequested(optionZTPCode) {
-		log.Debug("No ZTP option requested")
-		return resp, false
+	relayMsg := req.(*dhcpv6.RelayMessage)
+
+	// Handle ONIE installer request
+	if isONIERequest(m) {
+		handleONIE(relayMsg, m, resp)
 	}
 
-	relayMsg := req.(*dhcpv6.RelayMessage)
+	// Hanlde ZTP provisioning script request
+	if m.IsOptionRequested(optionZTPCode) {
+		handleZTP(relayMsg, resp)
+	}
+
+	return resp, false
+}
+
+// isONIERequest checks whether the DHCPv6 message is an ONIE discovery request
+// by verifying that Boot File URL (option 59) is requested and UserClass contains
+// "onie_dhcp_user_class".
+func isONIERequest(m *dhcpv6.Message) bool {
+	if !m.IsOptionRequested(dhcpv6.OptionBootfileURL) {
+		return false
+	}
+	userClasses := m.Options.UserClasses()
+	for _, uc := range userClasses {
+		if string(uc) == onieUserClass {
+			return true
+		}
+	}
+	return false
+}
+
+// getVendorClassData extracts the vendor class data string from the DHCPv6 message.
+// ONIE sends VendorClass with EnterpriseNumber=xyz (4-bytes) and data like "onie_vendor:x86_64-accton_as7726_32x-r0".
+func getVendorClassData(m *dhcpv6.Message) string {
+	opt := m.GetOneOption(dhcpv6.OptionVendorClass)
+	if opt == nil {
+		return ""
+	}
+
+	// Parse raw bytes: uint32 enterprise number + (uint16 length + data)*
+	vcc := opt.ToBytes()
+	if len(vcc) < 6 {
+		return ""
+	}
+
+	entNum := binary.BigEndian.Uint32(vcc[0:4])
+	if entNum != 0 {
+		return ""
+	}
+
+	dataLen := int(binary.BigEndian.Uint16(vcc[4:6]))
+	if len(vcc) < 6+dataLen {
+		return ""
+	}
+
+	return string(vcc[6 : 6+dataLen])
+}
+
+func handleONIE(relayMsg *dhcpv6.RelayMessage, m *dhcpv6.Message, resp dhcpv6.DHCPv6) {
+	if len(onieInstallers) == 0 {
+		log.Debug("No ONIE installers configured")
+		return
+	}
+
+	mac, err := helper.GetMAC(relayMsg, log)
+	if err != nil {
+		log.Errorf("could not get MAC address: %v", err)
+		return
+	}
+
+	// Check MAC is in inventory
+	macFound := false
+	for _, switchEntry := range inventory {
+		if switchEntry.MacAddress == mac.String() {
+			macFound = true
+			log.Infof("ONIE request from known switch %s (MAC %s)", switchEntry.Name, mac.String())
+			break
+		}
+	}
+	if !macFound {
+		log.Infof("ONIE request from unknown MAC %s, ignoring", mac.String())
+		return
+	}
+
+	vendorClass := getVendorClassData(m)
+	if vendorClass == "" {
+		log.Warning("ONIE request has no vendor class data")
+		return
+	}
+
+	installerURL, ok := onieInstallers[vendorClass]
+	if !ok {
+		log.Warningf("No ONIE installer configured for vendor %q", vendorClass)
+		return
+	}
+
+	bf := dhcpv6.OptBootFileURL(installerURL)
+	resp.AddOption(bf)
+	log.Infof("Added ONIE BootFileURL option: %s (vendor: %s)", installerURL, vendorClass)
+}
+
+func handleZTP(relayMsg *dhcpv6.RelayMessage, resp dhcpv6.DHCPv6) {
 	_, mac, err := eui64.ParseIP(relayMsg.PeerAddr)
 	if err != nil {
 		log.Errorf("could not parse peer address %s: %s", relayMsg.PeerAddr.String(), err)
-		return nil, true
+		return
 	}
 
 	switchMACFound := false
@@ -141,7 +280,18 @@ func handler6(req, resp dhcpv6.DHCPv6) (dhcpv6.DHCPv6, bool) {
 			log.Infof("MAC address %s found in inventory, switch: %s", mac.String(), switchEntry.Name)
 			switchMACFound = true
 
-			buf := []byte(switchEntry.ProvisioningScriptAddress)
+			// Use per-switch override if set, otherwise use global default
+			scriptAddr := switchEntry.ProvisioningScriptAddress
+			if scriptAddr == "" {
+				scriptAddr = globalProvisioningScriptAddress
+			}
+
+			if scriptAddr == "" {
+				log.Warningf("No provisioning script address configured for switch %s", switchEntry.Name)
+				break
+			}
+
+			buf := []byte(scriptAddr)
 			opt := &dhcpv6.OptionGeneric{
 				OptionCode: optionZTPCode,
 				OptionData: buf,
@@ -155,6 +305,4 @@ func handler6(req, resp dhcpv6.DHCPv6) (dhcpv6.DHCPv6, bool) {
 	if !switchMACFound {
 		log.Infof("MAC address %s not found in inventory", mac.String())
 	}
-
-	return resp, false
 }

--- a/plugins/ztp/plugin_test.go
+++ b/plugins/ztp/plugin_test.go
@@ -4,9 +4,11 @@
 package ztp
 
 import (
+	"encoding/binary"
 	"net"
 	"os"
 
+	"github.com/insomniacslk/dhcp/iana"
 	"github.com/mdlayher/netx/eui64"
 
 	"github.com/insomniacslk/dhcp/dhcpv6"
@@ -37,9 +39,9 @@ var _ = Describe("ZTP Plugin", func() {
 		})
 	})
 
-	Describe("DHCPv6 Message Handling", func() {
-		It("should return provisioning script for known MAC with ZTP option 239 requested", func() {
-			req := createRequest(inventoryMAC, true, true)
+	Describe("DHCPv6 ZTP Message Handling", func() {
+		It("should return global provisioning script for known MAC with ZTP option 239 requested", func() {
+			req := createZTPRequest(inventoryMAC, true, true)
 
 			stub, err := dhcpv6.NewMessage()
 			stub.MessageType = dhcpv6.MessageTypeReply
@@ -55,8 +57,25 @@ var _ = Describe("ZTP Plugin", func() {
 			Expect(opt.OptionData).To(Equal([]byte(testZtpProvisioningScriptPath)))
 		})
 
-		It("should not return provisioning script for not known MAC with ZTP option 239 requested", func() {
-			req := createRequest(nonInventoryMAC, true, true)
+		It("should return per-switch override provisioning script when configured", func() {
+			req := createZTPRequest(inventoryMACWithOverride, true, true)
+
+			stub, err := dhcpv6.NewMessage()
+			stub.MessageType = dhcpv6.MessageTypeReply
+			Expect(err).NotTo(HaveOccurred())
+			Expect(stub).NotTo(BeNil())
+
+			resp, stop := handler6(req, stub)
+			Expect(stop).To(BeFalse())
+
+			opt := resp.GetOneOption(optionZTPCode).(*dhcpv6.OptionGeneric)
+			Expect(opt).NotTo(BeNil())
+			Expect(int(opt.OptionCode)).To(Equal(optionZTPCode))
+			Expect(opt.OptionData).To(Equal([]byte(testZtpOverrideScriptPath)))
+		})
+
+		It("should not return provisioning script for unknown MAC with ZTP option 239 requested", func() {
+			req := createZTPRequest(nonInventoryMAC, true, true)
 
 			stub, err := dhcpv6.NewMessage()
 			stub.MessageType = dhcpv6.MessageTypeReply
@@ -71,7 +90,7 @@ var _ = Describe("ZTP Plugin", func() {
 		})
 
 		It("should not return provisioning script for known MAC with ZTP option 239 not requested", func() {
-			req := createRequest(inventoryMAC, true, false)
+			req := createZTPRequest(inventoryMAC, true, false)
 
 			stub, err := dhcpv6.NewMessage()
 			stub.MessageType = dhcpv6.MessageTypeReply
@@ -86,7 +105,7 @@ var _ = Describe("ZTP Plugin", func() {
 		})
 
 		It("should stop and break the plugin chain for non-relayed messages", func() {
-			req := createRequest("11:22:33:44:55:66", false, false)
+			req := createZTPRequest("11:22:33:44:55:66", false, false)
 
 			stub, err := dhcpv6.NewMessage()
 			stub.MessageType = dhcpv6.MessageTypeReply
@@ -98,9 +117,81 @@ var _ = Describe("ZTP Plugin", func() {
 			Expect(resp).To(BeNil())
 		})
 	})
+
+	Describe("DHCPv6 ONIE Message Handling", func() {
+		It("should return Boot File URL for known MAC with matching vendor", func() {
+			req := createONIERequest(inventoryMAC, testONIEVendor)
+
+			stub, err := dhcpv6.NewMessage()
+			stub.MessageType = dhcpv6.MessageTypeReply
+			Expect(err).NotTo(HaveOccurred())
+
+			resp, stop := handler6(req, stub)
+			Expect(stop).To(BeFalse())
+
+			bootFileURL := resp.(*dhcpv6.Message).Options.BootFileURL()
+			Expect(bootFileURL).To(Equal(testONIEInstallerURL))
+		})
+
+		It("should not return Boot File URL for unknown MAC", func() {
+			req := createONIERequest(nonInventoryMAC, testONIEVendor)
+
+			stub, err := dhcpv6.NewMessage()
+			stub.MessageType = dhcpv6.MessageTypeReply
+			Expect(err).NotTo(HaveOccurred())
+
+			resp, stop := handler6(req, stub)
+			Expect(stop).To(BeFalse())
+
+			opts := resp.GetOption(dhcpv6.OptionBootfileURL)
+			Expect(opts).To(BeEmpty())
+		})
+
+		It("should not return Boot File URL for known MAC with unknown vendor", func() {
+			req := createONIERequest(inventoryMAC, testONIEUnknownVendor)
+
+			stub, err := dhcpv6.NewMessage()
+			stub.MessageType = dhcpv6.MessageTypeReply
+			Expect(err).NotTo(HaveOccurred())
+
+			resp, stop := handler6(req, stub)
+			Expect(stop).To(BeFalse())
+
+			opts := resp.GetOption(dhcpv6.OptionBootfileURL)
+			Expect(opts).To(BeEmpty())
+		})
+
+		It("should not handle ONIE when Boot File URL is not requested in ORO", func() {
+			req := createONIERequestWithoutBootFileURL(inventoryMAC, testONIEVendor)
+
+			stub, err := dhcpv6.NewMessage()
+			stub.MessageType = dhcpv6.MessageTypeReply
+			Expect(err).NotTo(HaveOccurred())
+
+			resp, stop := handler6(req, stub)
+			Expect(stop).To(BeFalse())
+
+			opts := resp.GetOption(dhcpv6.OptionBootfileURL)
+			Expect(opts).To(BeEmpty())
+		})
+
+		It("should not handle ONIE when UserClass is missing", func() {
+			req := createONIERequestWithoutUserClass(inventoryMAC, testONIEVendor)
+
+			stub, err := dhcpv6.NewMessage()
+			stub.MessageType = dhcpv6.MessageTypeReply
+			Expect(err).NotTo(HaveOccurred())
+
+			resp, stop := handler6(req, stub)
+			Expect(stop).To(BeFalse())
+
+			opts := resp.GetOption(dhcpv6.OptionBootfileURL)
+			Expect(opts).To(BeEmpty())
+		})
+	})
 })
 
-func createRequest(mac string, relayed bool, optZTPRequested bool) dhcpv6.DHCPv6 {
+func createZTPRequest(mac string, relayed bool, optZTPRequested bool) dhcpv6.DHCPv6 {
 	hwAddr, err := net.ParseMAC(mac)
 	Expect(err).NotTo(HaveOccurred())
 	Expect(hwAddr).NotTo(BeNil())
@@ -129,4 +220,113 @@ func createRequest(mac string, relayed bool, optZTPRequested bool) dhcpv6.DHCPv6
 	}
 
 	return req
+}
+
+func createONIERequest(mac string, vendorClassData string) dhcpv6.DHCPv6 {
+	hwAddr, err := net.ParseMAC(mac)
+	Expect(err).NotTo(HaveOccurred())
+
+	i := net.ParseIP(linkLocalIPV6Prefix)
+	linkLocalIPV6Addr, err := eui64.ParseMAC(i, hwAddr)
+	Expect(err).NotTo(HaveOccurred())
+
+	req, err := dhcpv6.NewMessage()
+	Expect(err).NotTo(HaveOccurred())
+	req.MessageType = dhcpv6.MessageTypeRequest
+
+	// Request Boot File URL (option 59)
+	req.AddOption(dhcpv6.OptRequestedOption(dhcpv6.OptionBootfileURL))
+
+	// Add UserClass with "onie_dhcp_user_class"
+	addONIEUserClass(req)
+
+	// Add VendorClass with EnterpriseNumber=0 and vendor data
+	addONIEVendorClass(req, vendorClassData)
+
+	// Wrap in relay with ClientLinkLayerAddress
+	relayedRequest, err := dhcpv6.EncapsulateRelay(req, dhcpv6.MessageTypeRelayForward,
+		net.ParseIP("2001:db8:1111:2222:3333:4444:5555:6666"), linkLocalIPV6Addr)
+	Expect(err).NotTo(HaveOccurred())
+
+	// Add Client Link-Layer Address option to relay
+	relayedRequest.AddOption(dhcpv6.OptClientLinkLayerAddress(iana.HWTypeEthernet, hwAddr))
+
+	return relayedRequest
+}
+
+func createONIERequestWithoutBootFileURL(mac string, vendorClassData string) dhcpv6.DHCPv6 {
+	hwAddr, err := net.ParseMAC(mac)
+	Expect(err).NotTo(HaveOccurred())
+
+	i := net.ParseIP(linkLocalIPV6Prefix)
+	linkLocalIPV6Addr, err := eui64.ParseMAC(i, hwAddr)
+	Expect(err).NotTo(HaveOccurred())
+
+	req, err := dhcpv6.NewMessage()
+	Expect(err).NotTo(HaveOccurred())
+	req.MessageType = dhcpv6.MessageTypeRequest
+
+	// Do NOT request Boot File URL — just request something else
+	req.AddOption(dhcpv6.OptRequestedOption(dhcpv6.OptionDNSRecursiveNameServer))
+
+	addONIEUserClass(req)
+	addONIEVendorClass(req, vendorClassData)
+
+	relayedRequest, err := dhcpv6.EncapsulateRelay(req, dhcpv6.MessageTypeRelayForward,
+		net.ParseIP("2001:db8:1111:2222:3333:4444:5555:6666"), linkLocalIPV6Addr)
+	Expect(err).NotTo(HaveOccurred())
+	relayedRequest.AddOption(dhcpv6.OptClientLinkLayerAddress(iana.HWTypeEthernet, hwAddr))
+
+	return relayedRequest
+}
+
+func createONIERequestWithoutUserClass(mac string, vendorClassData string) dhcpv6.DHCPv6 {
+	hwAddr, err := net.ParseMAC(mac)
+	Expect(err).NotTo(HaveOccurred())
+
+	i := net.ParseIP(linkLocalIPV6Prefix)
+	linkLocalIPV6Addr, err := eui64.ParseMAC(i, hwAddr)
+	Expect(err).NotTo(HaveOccurred())
+
+	req, err := dhcpv6.NewMessage()
+	Expect(err).NotTo(HaveOccurred())
+	req.MessageType = dhcpv6.MessageTypeRequest
+
+	// Request Boot File URL but do NOT add UserClass
+	req.AddOption(dhcpv6.OptRequestedOption(dhcpv6.OptionBootfileURL))
+
+	addONIEVendorClass(req, vendorClassData)
+
+	relayedRequest, err := dhcpv6.EncapsulateRelay(req, dhcpv6.MessageTypeRelayForward,
+		net.ParseIP("2001:db8:1111:2222:3333:4444:5555:6666"), linkLocalIPV6Addr)
+	Expect(err).NotTo(HaveOccurred())
+	relayedRequest.AddOption(dhcpv6.OptClientLinkLayerAddress(iana.HWTypeEthernet, hwAddr))
+
+	return relayedRequest
+}
+
+func addONIEUserClass(req *dhcpv6.Message) {
+	userClassData := []byte(onieUserClass)
+	buf := make([]byte, 2+len(userClassData))
+	binary.BigEndian.PutUint16(buf[0:2], uint16(len(userClassData)))
+	copy(buf[2:], userClassData)
+
+	optUserClass := dhcpv6.OptUserClass{}
+	err := optUserClass.FromBytes(buf)
+	Expect(err).NotTo(HaveOccurred())
+	req.UpdateOption(&optUserClass)
+}
+
+func addONIEVendorClass(req *dhcpv6.Message, vendorData string) {
+	data := []byte(vendorData)
+	// Wire format: uint32 enterprise number (0) + uint16 length + data
+	buf := make([]byte, 4+2+len(data))
+	binary.BigEndian.PutUint32(buf[0:4], 0) // EnterpriseNumber = 0
+	binary.BigEndian.PutUint16(buf[4:6], uint16(len(data)))
+	copy(buf[6:], data)
+
+	optVendorClass := dhcpv6.OptVendorClass{}
+	err := optVendorClass.FromBytes(buf)
+	Expect(err).NotTo(HaveOccurred())
+	req.UpdateOption(&optVendorClass)
 }

--- a/plugins/ztp/plugin_test.go
+++ b/plugins/ztp/plugin_test.go
@@ -4,11 +4,9 @@
 package ztp
 
 import (
-	"encoding/binary"
 	"net"
 	"os"
 
-	"github.com/insomniacslk/dhcp/iana"
 	"github.com/mdlayher/netx/eui64"
 
 	"github.com/insomniacslk/dhcp/dhcpv6"
@@ -117,78 +115,6 @@ var _ = Describe("ZTP Plugin", func() {
 			Expect(resp).To(BeNil())
 		})
 	})
-
-	Describe("DHCPv6 ONIE Message Handling", func() {
-		It("should return Boot File URL for known MAC with matching vendor", func() {
-			req := createONIERequest(inventoryMAC, testONIEVendor)
-
-			stub, err := dhcpv6.NewMessage()
-			stub.MessageType = dhcpv6.MessageTypeReply
-			Expect(err).NotTo(HaveOccurred())
-
-			resp, stop := handler6(req, stub)
-			Expect(stop).To(BeFalse())
-
-			bootFileURL := resp.(*dhcpv6.Message).Options.BootFileURL()
-			Expect(bootFileURL).To(Equal(testONIEInstallerURL))
-		})
-
-		It("should not return Boot File URL for unknown MAC", func() {
-			req := createONIERequest(nonInventoryMAC, testONIEVendor)
-
-			stub, err := dhcpv6.NewMessage()
-			stub.MessageType = dhcpv6.MessageTypeReply
-			Expect(err).NotTo(HaveOccurred())
-
-			resp, stop := handler6(req, stub)
-			Expect(stop).To(BeFalse())
-
-			opts := resp.GetOption(dhcpv6.OptionBootfileURL)
-			Expect(opts).To(BeEmpty())
-		})
-
-		It("should not return Boot File URL for known MAC with unknown vendor", func() {
-			req := createONIERequest(inventoryMAC, testONIEUnknownVendor)
-
-			stub, err := dhcpv6.NewMessage()
-			stub.MessageType = dhcpv6.MessageTypeReply
-			Expect(err).NotTo(HaveOccurred())
-
-			resp, stop := handler6(req, stub)
-			Expect(stop).To(BeFalse())
-
-			opts := resp.GetOption(dhcpv6.OptionBootfileURL)
-			Expect(opts).To(BeEmpty())
-		})
-
-		It("should not handle ONIE when Boot File URL is not requested in ORO", func() {
-			req := createONIERequestWithoutBootFileURL(inventoryMAC, testONIEVendor)
-
-			stub, err := dhcpv6.NewMessage()
-			stub.MessageType = dhcpv6.MessageTypeReply
-			Expect(err).NotTo(HaveOccurred())
-
-			resp, stop := handler6(req, stub)
-			Expect(stop).To(BeFalse())
-
-			opts := resp.GetOption(dhcpv6.OptionBootfileURL)
-			Expect(opts).To(BeEmpty())
-		})
-
-		It("should not handle ONIE when UserClass is missing", func() {
-			req := createONIERequestWithoutUserClass(inventoryMAC, testONIEVendor)
-
-			stub, err := dhcpv6.NewMessage()
-			stub.MessageType = dhcpv6.MessageTypeReply
-			Expect(err).NotTo(HaveOccurred())
-
-			resp, stop := handler6(req, stub)
-			Expect(stop).To(BeFalse())
-
-			opts := resp.GetOption(dhcpv6.OptionBootfileURL)
-			Expect(opts).To(BeEmpty())
-		})
-	})
 })
 
 func createZTPRequest(mac string, relayed bool, optZTPRequested bool) dhcpv6.DHCPv6 {
@@ -220,113 +146,4 @@ func createZTPRequest(mac string, relayed bool, optZTPRequested bool) dhcpv6.DHC
 	}
 
 	return req
-}
-
-func createONIERequest(mac string, vendorClassData string) dhcpv6.DHCPv6 {
-	hwAddr, err := net.ParseMAC(mac)
-	Expect(err).NotTo(HaveOccurred())
-
-	i := net.ParseIP(linkLocalIPV6Prefix)
-	linkLocalIPV6Addr, err := eui64.ParseMAC(i, hwAddr)
-	Expect(err).NotTo(HaveOccurred())
-
-	req, err := dhcpv6.NewMessage()
-	Expect(err).NotTo(HaveOccurred())
-	req.MessageType = dhcpv6.MessageTypeRequest
-
-	// Request Boot File URL (option 59)
-	req.AddOption(dhcpv6.OptRequestedOption(dhcpv6.OptionBootfileURL))
-
-	// Add UserClass with "onie_dhcp_user_class"
-	addONIEUserClass(req)
-
-	// Add VendorClass with EnterpriseNumber=0 and vendor data
-	addONIEVendorClass(req, vendorClassData)
-
-	// Wrap in relay with ClientLinkLayerAddress
-	relayedRequest, err := dhcpv6.EncapsulateRelay(req, dhcpv6.MessageTypeRelayForward,
-		net.ParseIP("2001:db8:1111:2222:3333:4444:5555:6666"), linkLocalIPV6Addr)
-	Expect(err).NotTo(HaveOccurred())
-
-	// Add Client Link-Layer Address option to relay
-	relayedRequest.AddOption(dhcpv6.OptClientLinkLayerAddress(iana.HWTypeEthernet, hwAddr))
-
-	return relayedRequest
-}
-
-func createONIERequestWithoutBootFileURL(mac string, vendorClassData string) dhcpv6.DHCPv6 {
-	hwAddr, err := net.ParseMAC(mac)
-	Expect(err).NotTo(HaveOccurred())
-
-	i := net.ParseIP(linkLocalIPV6Prefix)
-	linkLocalIPV6Addr, err := eui64.ParseMAC(i, hwAddr)
-	Expect(err).NotTo(HaveOccurred())
-
-	req, err := dhcpv6.NewMessage()
-	Expect(err).NotTo(HaveOccurred())
-	req.MessageType = dhcpv6.MessageTypeRequest
-
-	// Do NOT request Boot File URL — just request something else
-	req.AddOption(dhcpv6.OptRequestedOption(dhcpv6.OptionDNSRecursiveNameServer))
-
-	addONIEUserClass(req)
-	addONIEVendorClass(req, vendorClassData)
-
-	relayedRequest, err := dhcpv6.EncapsulateRelay(req, dhcpv6.MessageTypeRelayForward,
-		net.ParseIP("2001:db8:1111:2222:3333:4444:5555:6666"), linkLocalIPV6Addr)
-	Expect(err).NotTo(HaveOccurred())
-	relayedRequest.AddOption(dhcpv6.OptClientLinkLayerAddress(iana.HWTypeEthernet, hwAddr))
-
-	return relayedRequest
-}
-
-func createONIERequestWithoutUserClass(mac string, vendorClassData string) dhcpv6.DHCPv6 {
-	hwAddr, err := net.ParseMAC(mac)
-	Expect(err).NotTo(HaveOccurred())
-
-	i := net.ParseIP(linkLocalIPV6Prefix)
-	linkLocalIPV6Addr, err := eui64.ParseMAC(i, hwAddr)
-	Expect(err).NotTo(HaveOccurred())
-
-	req, err := dhcpv6.NewMessage()
-	Expect(err).NotTo(HaveOccurred())
-	req.MessageType = dhcpv6.MessageTypeRequest
-
-	// Request Boot File URL but do NOT add UserClass
-	req.AddOption(dhcpv6.OptRequestedOption(dhcpv6.OptionBootfileURL))
-
-	addONIEVendorClass(req, vendorClassData)
-
-	relayedRequest, err := dhcpv6.EncapsulateRelay(req, dhcpv6.MessageTypeRelayForward,
-		net.ParseIP("2001:db8:1111:2222:3333:4444:5555:6666"), linkLocalIPV6Addr)
-	Expect(err).NotTo(HaveOccurred())
-	relayedRequest.AddOption(dhcpv6.OptClientLinkLayerAddress(iana.HWTypeEthernet, hwAddr))
-
-	return relayedRequest
-}
-
-func addONIEUserClass(req *dhcpv6.Message) {
-	userClassData := []byte(onieUserClass)
-	buf := make([]byte, 2+len(userClassData))
-	binary.BigEndian.PutUint16(buf[0:2], uint16(len(userClassData)))
-	copy(buf[2:], userClassData)
-
-	optUserClass := dhcpv6.OptUserClass{}
-	err := optUserClass.FromBytes(buf)
-	Expect(err).NotTo(HaveOccurred())
-	req.UpdateOption(&optUserClass)
-}
-
-func addONIEVendorClass(req *dhcpv6.Message, vendorData string) {
-	data := []byte(vendorData)
-	// Wire format: uint32 enterprise number (0) + uint16 length + data
-	buf := make([]byte, 4+2+len(data))
-	binary.BigEndian.PutUint32(buf[0:4], 0) // EnterpriseNumber = 0
-	binary.BigEndian.PutUint16(buf[4:6], uint16(len(data)))
-	copy(buf[6:], data)
-
-	optVendorClass := dhcpv6.OptVendorClass{}
-	err := optVendorClass.FromBytes(buf)
-	Expect(err).NotTo(HaveOccurred())
-	req.UpdateOption(&optVendorClass)
 }

--- a/plugins/ztp/suite_test.go
+++ b/plugins/ztp/suite_test.go
@@ -24,9 +24,14 @@ const (
 	consistentlyDuration          = 1 * time.Second
 	testConfigPath                = "config.yaml"
 	testZtpProvisioningScriptPath = "https://[2001:db8::1]/ztp/provisioning.sh"
+	testZtpOverrideScriptPath     = "https://[2001:db8::1]/ztp/provision-override.sh"
 	linkLocalIPV6Prefix           = "fe80::"
 	inventoryMAC                  = "00:11:22:33:44:55"
+	inventoryMACWithOverride      = "00:11:22:33:44:66"
 	nonInventoryMAC               = "47:11:47:11:47:11"
+	testONIEVendor                = "onie_vendor:x86_64-accton_as7726_32x-r0"
+	testONIEInstallerURL          = "http://[2001:db8::1]/onie/accton_as7726_32x.bin"
+	testONIEUnknownVendor         = "onie_vendor:x86_64-unknown_switch-r0"
 )
 
 func TestZTP(t *testing.T) {
@@ -45,11 +50,22 @@ var _ = BeforeSuite(func() {
 
 	configFile := testConfigPath
 	config := &api.ZTPConfig{
+		ProvisioningScriptAddress: testZtpProvisioningScriptPath,
 		Switches: []api.Switch{
 			{
-				MacAddress:                inventoryMAC,
-				ProvisioningScriptAddress: testZtpProvisioningScriptPath,
-				Name:                      "test-switch",
+				MacAddress: inventoryMAC,
+				Name:       "test-switch",
+			},
+			{
+				MacAddress:                inventoryMACWithOverride,
+				ProvisioningScriptAddress: testZtpOverrideScriptPath,
+				Name:                      "test-switch-override",
+			},
+		},
+		ONIEInstallers: []api.ONIEInstaller{
+			{
+				Vendor:       testONIEVendor,
+				InstallerURL: testONIEInstallerURL,
 			},
 		},
 	}
@@ -65,5 +81,6 @@ var _ = BeforeSuite(func() {
 
 	_, err = setup6(file.Name())
 	Expect(err).NotTo(HaveOccurred())
-	Expect(inventory).To(HaveLen(1))
+	Expect(inventory).To(HaveLen(2))
+	Expect(onieInstallers).To(HaveLen(1))
 })


### PR DESCRIPTION
This PR provides enhancement on the ztp plugin and the new ONIE plugin.

1) the ztp plugin is enhanced in the sense that a general URL to access ztp script is provided. If any switch needs a special url for its ztp script, specifying such a url in the config file overwrites the general Url.
2) the new onie plugin checks if a dhcp6 request contains `OptionBootfileURL` option and a special `UserClass` option for determining if it is an onie dhcp6 request. Thus, no conflict with other plugins.

Local tests are included. Also deployed and tested in fra3.