### PR TITLE
Update release-drafter workflow for v7

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,24 +1,39 @@
 name: Release Drafter
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main
-  pull_request:
+      - release-**
+  pull_request_target:
+    types: [ opened, reopened, synchronize ]
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
+  pull-requests: read
 
 jobs:
   update_release_draft:
+    name: Run release drafter
+    if: github.event_name != 'pull_request_target'
+    permissions:
+      contents: write
+      pull-requests: read
     runs-on: ubuntu-latest
     steps:
       # Drafts your next Release notes as Pull Requests are merged into "main"
+      # or a release branch
       - uses: release-drafter/release-drafter@v7
         with:
-          disable-releaser: github.ref != 'refs/heads/main'
-          config-name: release-drafter.yml
-          commitish: main
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          commitish: ${{ github.ref_name }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+  auto_label:
+    name: Run autolabeler
+    if: github.event_name == 'pull_request_target'
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter/autolabeler@v7


### PR DESCRIPTION
# Proposed Changes

Split release drafter into two jobs: one for drafting releases on push
(supporting main and release branches), and one for auto-labeling PRs
via `pull_request_target`.

This change is required after the release-drafter v7 update, because
autolabeler is now a dedicated action and no longer bundled with the
release-drafter action.
