### PR TITLE
Fix release drafter

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,24 +1,35 @@
 name: Release Drafter
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main
-  pull_request:
+  pull_request_target:
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
+  pull-requests: read
 
 jobs:
   update_release_draft:
+    name: Run release drafter
+    if: github.event_name != 'pull_request_target'
+    permissions:
+      contents: write
+      pull-requests: read
     runs-on: ubuntu-latest
     steps:
-      # Drafts your next Release notes as Pull Requests are merged into "main"
       - uses: release-drafter/release-drafter@v7
         with:
-          disable-releaser: github.ref != 'refs/heads/main'
-          config-name: release-drafter.yml
-          commitish: main
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          commitish: ${{ github.ref_name }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+  auto_label:
+    name: Run autolabeler
+    if: github.event_name == 'pull_request_target'
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter/autolabeler@v7


### PR DESCRIPTION
- run the autolabeler explicitly
- use `pull_request_target` as trigger

